### PR TITLE
chore: retire rebuild branch CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - "master"
-      - "rebuild/**"
   pull_request:
     branches:
       - "master"
-      - "rebuild/**"
 
 permissions:
   contents: read

--- a/tests/contract/ci-pinning.test.ts
+++ b/tests/contract/ci-pinning.test.ts
@@ -37,13 +37,16 @@ describe("CI workflow hardening", () => {
     expect(raw.toLowerCase()).not.toContain("npm publish");
   });
 
-  it("triggers on master push/PR in addition to rebuild/** branches", () => {
-    // Release-transition requirement (TASK-0004): CI must gate master pushes
-    // and PRs targeting master while keeping rebuild/** coverage.
-    expect(raw).toMatch(/push:\s*\n\s*branches:\s*\n\s*-\s*"master"\s*\n\s*-\s*"rebuild\/\*\*"/);
-    expect(raw).toMatch(
-      /pull_request:\s*\n\s*branches:\s*\n\s*-\s*"master"\s*\n\s*-\s*"rebuild\/\*\*"/,
-    );
+  it("triggers only on master push/PR after the rebuild branch is retired", () => {
+    const doc = parse(raw) as {
+      on?: {
+        push?: { branches?: string[] };
+        pull_request?: { branches?: string[] };
+      };
+    };
+    expect(doc.on?.push?.branches).toEqual(["master"]);
+    expect(doc.on?.pull_request?.branches).toEqual(["master"]);
+    expect(raw).not.toContain("rebuild/**");
   });
 
   it("covers the required matrix and hardening jobs", () => {
@@ -79,7 +82,6 @@ describe("release workflow hardening", () => {
 
   it("triggers on version tags only — never on branch pushes", () => {
     expect(raw).toMatch(/tags:\s*\n\s*-\s*"v\*\.\*\.\*"/);
-    // The push trigger block must not carry a branches selector.
     const pushBlock = /on:\s*\n\s*push:\s*\n(?:.*\n)*?\s*permissions:/m.exec(raw)?.[0] ?? "";
     expect(pushBlock).not.toMatch(/branches:/);
   });
@@ -99,24 +101,14 @@ describe("release workflow hardening", () => {
   });
 
   it("gates on an anchored exact-tag regex, checkout identity, and package/version parity", () => {
-    // Regression guard: the former `case` glob (`v[0-9]*.[0-9]*.[0-9]*`)
-    // accepted non-exact tags such as `v0.1.1-beta` or `v1.2.3.4` because a
-    // glob `*` spans dots and suffixes. Only an anchored regex is exact.
     expect(raw).not.toContain("v[0-9]*.[0-9]*.[0-9]*)");
-    // The ${...} sequences below are LITERAL shell/YAML text asserted inside
-    // release.yml, not template interpolations.
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash text under test
     expect(raw).toContain('if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then');
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash text under test
     expect(raw).toContain('"${TAG_COMMIT}" != "${HEAD_COMMIT}"');
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal error message under test
     expect(raw).toContain("'${PKG_VERSION}' does not match tag");
     expect(raw).toContain("@cynrath/agent-context-kit");
   });
 
   it("rejects malformed tags and accepts only exact vX.Y.Z releases (behavioral)", () => {
-    // Extract the actual guard regex from release.yml so this regression test
-    // exercises the shipped validation instead of re-implementing it.
     const guard = raw.match(/if \[\[ ! "\$\{TAG_NAME\}" =~ (.+?) \]\]; then/);
     expect(guard, "release.yml must gate TAG_NAME on an anchored regex").not.toBeNull();
     const tagRule = new RegExp(guard?.[1] ?? "(?!)");
@@ -128,7 +120,6 @@ describe("release workflow hardening", () => {
     for (const tag of rejected) {
       expect(tagRule.test(tag), `malformed tag '${tag}' must fail the shape gate`).toBe(false);
     }
-    // The failure branch must be loud and blocking.
     expect(raw).toMatch(/::error::tag/);
     expect(raw).toContain("is not an exact vX.Y.Z release tag");
   });
@@ -142,7 +133,6 @@ describe("release workflow hardening", () => {
     const tests = order("run: pnpm test");
     const smoke = order("run: pnpm run smoke:package");
     const absence = order("Confirm exact version is absent from the npm registry");
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash text under test
     const publish = order('run: npm publish "${TARBALL_PATH}" --access public');
     expect(tests).toBeLessThan(publish);
     expect(smoke).toBeLessThan(publish);
@@ -150,7 +140,6 @@ describe("release workflow hardening", () => {
   });
 
   it("creates the GitHub Release only AFTER publish + registry + npx verification", () => {
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash text under test
     const publish = raw.indexOf('run: npm publish "${TARBALL_PATH}" --access public');
     const verify = raw.indexOf("Verify registry metadata, shasum, and dist-tag");
     const npxSmoke = raw.indexOf("Real registry npx consumer smoke");
@@ -163,16 +152,9 @@ describe("release workflow hardening", () => {
   });
 
   it("publishes the recorded tarball and parses registry metadata safely", () => {
-    // Regression (v0.1.1 release incident): argument-less `npm publish`
-    // re-packs, and this package's prepack hook rewrites dist/ mtimes, so a
-    // second pack can never be byte-identical to the recorded tarball.
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash text under test
     expect(raw).toContain('npm publish "${TARBALL_PATH}"');
-    // Multi-field `npm view` prints `key = 'value'` text; slicing that output
-    // produced a bogus shasum comparison. The value must come from JSON.
     expect(raw).toContain("dist.shasum --json");
     expect(raw).toContain("JSON.parse(require('fs').readFileSync(0,'utf8'))");
-    // Bounded but generous propagation window (>= 5 minutes).
     expect(raw).toMatch(/seq 1 30/);
   });
 
@@ -182,8 +164,6 @@ describe("release workflow hardening", () => {
     );
     expect(releaseStep).toBeGreaterThan(-1);
     expect(releaseStep).toBe(raw.lastIndexOf("- name:"));
-    // Sequential steps under `set -euo pipefail` mean any earlier failure
-    // (publish, registry verify, npx smoke) aborts the job before this step.
     expect(raw).toContain("set -euo pipefail");
   });
 
@@ -193,9 +173,6 @@ describe("release workflow hardening", () => {
   });
 
   it("parses as strict YAML with tags-only push semantics (startup-failure guard)", () => {
-    // An unparseable workflow makes GitHub fall back to default triggers and
-    // record startup failures on EVERY push; this assertion keeps the file
-    // machine-valid before it can reach master.
     const doc = parse(raw) as {
       on?: {
         push?: { tags?: string[]; branches?: string[] };
@@ -207,7 +184,6 @@ describe("release workflow hardening", () => {
     };
     expect(doc.on?.push?.tags).toContain("v*.*.*");
     expect(doc.on?.push?.branches).toBeUndefined();
-    // Master/PR pushes and manual dispatches must never be able to publish.
     expect(doc.on?.pull_request).toBeUndefined();
     expect(doc.on?.workflow_dispatch).toBeUndefined();
     expect(Object.keys(doc.jobs ?? {})).toEqual(["release"]);


### PR DESCRIPTION
Retires the obsolete `rebuild/**` CI triggers now that vNext is fully on `master`, and updates the CI contract test to require master-only push/PR coverage. No release or package changes.