### PR TITLE
chore: formalize post-v0.2.2 feedback and benchmark loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark_report.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark_report.yml
@@ -1,0 +1,78 @@
+name: Benchmark or performance report
+description: Submit reproducible ACKit benchmark/performance evidence from a real repository or sanitized fixture.
+title: "[Benchmark]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ACKit benchmark reports should be reproducible and privacy-safe. Do not upload repository source, secrets, raw secret findings, or absolute local paths. Prefer aggregate metrics and a public repository + exact commit SHA when possible.
+  - type: input
+    id: version
+    attributes:
+      label: ACKit version
+      placeholder: 0.2.2
+    validations:
+      required: true
+  - type: input
+    id: repository
+    attributes:
+      label: Repository or fixture
+      description: Public `owner/repo@SHA`, or a short description such as `private TypeScript monorepo (sanitized aggregate only)`.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, CPU class, RAM, and repository ecosystem if relevant.
+      placeholder: Ubuntu 24.04, Node 24, 8 vCPU, 16 GB RAM, TypeScript
+    validations:
+      required: true
+  - type: dropdown
+    id: metric
+    attributes:
+      label: Primary metric
+      multiple: true
+      options:
+        - Cold scan time
+        - Warm scan time
+        - Incremental scan time
+        - Files per second
+        - Peak RSS memory
+        - Context pack time
+        - Instruction graph time
+        - Cache hit ratio
+        - Other deterministic metric
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Reproduction command and setup
+      description: Include enough sanitized detail to repeat the run. Pin repository SHA/config where possible.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: results
+    attributes:
+      label: Results
+      description: Prefer median-of-3 or more, with units and run count. Include comparison data only if measured under the same conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Why is this result notable?
+      description: Regression, improvement, scale limit, cross-platform difference, or reproducibility concern.
+    validations:
+      required: true
+  - type: checkboxes
+    id: methodology
+    attributes:
+      label: Methodology and privacy
+      options:
+        - label: I did not include secrets, private source content, raw secret findings, or absolute local paths.
+          required: true
+        - label: Any comparison numbers were collected under equivalent conditions or are clearly marked otherwise.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,13 +2,16 @@ blank_issues_enabled: false
 contact_links:
   - name: GitHub Discussions (Q&A, Ideas, Show and tell)
     url: https://github.com/Cynrath/agent-context-kit/discussions
-    about: Open community conversation, support questions, and feature proposals. Security reports stay in SECURITY.md, not Discussions.
+    about: Open community conversation, support questions, workflow ideas, comparisons, and show-and-tell. Security reports stay in SECURITY.md, not Discussions.
+  - name: Maintenance mode and feedback policy
+    url: https://github.com/Cynrath/agent-context-kit/blob/master/docs/MAINTENANCE_MODE.md
+    about: How post-v0.2.2 feedback, benchmark evidence, maintenance fixes, and future-version decisions are handled.
   - name: Security vulnerability disclosure
     url: https://github.com/Cynrath/agent-context-kit/security/policy
     about: Please follow SECURITY.md for vulnerability reports. Do not disclose sensitive details in public issues.
   - name: General documentation
-    url: https://github.com/Cynrath/agent-context-kit/blob/master/docs/DOCUMENTATION_INDEX.md
-    about: Start here for usage, release, support, and maintainer documentation.
+    url: https://github.com/Cynrath/agent-context-kit#readme
+    about: Start with the repository README for installation, usage, architecture, support, and documentation links.
   - name: Sponsor Cynrath
     url: https://github.com/sponsors/Cynrath
     about: Support the maintainer via GitHub Sponsors (see .github/FUNDING.yml).

--- a/.github/ISSUE_TEMPLATE/usage_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/usage_feedback.yml
@@ -1,0 +1,72 @@
+name: Real-world usage feedback
+description: Share how ACKit behaves in a real repository so maintainers can prioritize evidence-backed improvements.
+title: "[Usage]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using ACKit. This form is for concrete experience from a real repository. Please remove secrets, private URLs, absolute local paths, and proprietary source content.
+  - type: input
+    id: version
+    attributes:
+      label: ACKit version
+      description: Output of `ackit --version`.
+      placeholder: 0.2.2
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface used
+      multiple: true
+      options:
+        - CLI
+        - VS Code extension
+        - GitHub Action
+        - MCP
+        - TypeScript/Node SDK
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, and repository ecosystem. Do not include usernames or absolute paths.
+      placeholder: Windows 11, Node 24, TypeScript monorepo
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What were you trying to do?
+      description: Describe the workflow and expected outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: What happened?
+      description: Include commands, sanitized output, readiness/scan summaries, or observed behavior when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: What was useful or not useful?
+      description: Tell us which findings, views, reports, or workflows saved time or created noise.
+    validations:
+      required: true
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Smallest improvement that would matter
+      description: Prefer the concrete problem over a proposed implementation.
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed secrets, credentials, private repository content, private URLs, and machine-specific absolute paths.
+          required: true

--- a/docs/MAINTENANCE_MODE.md
+++ b/docs/MAINTENANCE_MODE.md
@@ -1,0 +1,91 @@
+# Post-v0.2.2 Maintenance Mode
+
+AgentContextKit is in a stabilization and evidence-gathering phase after `v0.2.2`.
+
+This is not abandonment and it is not a feature freeze forever. The purpose is to let real usage, issues, Discussions, and reproducible benchmark evidence determine the next product work instead of immediately creating a new version roadmap from assumptions.
+
+## Current policy
+
+- Keep `v0.2.2` tag, npm package, GitHub Release, VS Code Marketplace release, and Action release immutable.
+- Do not create a new version for documentation, test-only, CI-only, or community-process maintenance.
+- Accept narrowly scoped bug fixes when evidence shows a product defect.
+- Treat security, data-loss, correctness, offline-first, deterministic-output, release-integrity, and cross-platform regressions as priority maintenance.
+- Avoid speculative feature work until enough user evidence exists to justify it.
+
+## Where feedback goes
+
+| Feedback | Preferred channel |
+| --- | --- |
+| Reproducible product bug | GitHub Issue → Bug report |
+| Concrete experience from a real repository | GitHub Issue → Real-world usage feedback |
+| Reproducible performance/benchmark evidence | GitHub Issue → Benchmark or performance report |
+| Questions, ideas, workflows, comparisons, show-and-tell | GitHub Discussions |
+| Documentation defect | GitHub Issue → Documentation improvement |
+| Security vulnerability | Private process in `SECURITY.md` / GitHub Security policy |
+
+Do not post secrets, credentials, private source code, raw secret findings, private URLs, or machine-specific absolute paths in public reports.
+
+## Evidence we care about
+
+The maintainer should prioritize repeated evidence rather than raw request count. Useful signals include:
+
+1. The same failure or workflow friction reproduced by multiple independent repositories.
+2. A finding category that users consistently mark as noisy, misleading, or high-value.
+3. Cross-platform differences across Windows, Linux, and macOS.
+4. Measurable regressions in cold/warm/incremental scan time, memory, graph/pack time, or cache behavior.
+5. Missing provider/repository patterns that block otherwise normal agent workflows.
+6. Security or privacy behavior that violates the documented offline-first contract.
+
+## Benchmark requirements
+
+Canonical public methodology remains `docs/benchmarks/public-evidence.md`.
+
+External benchmark reports should, where practical:
+
+- pin ACKit version;
+- pin a public repository commit SHA, or provide sanitized aggregate-only private-repository context;
+- record OS, Node version, repository ecosystem, and relevant machine class;
+- use median-of-3 or more for performance claims;
+- compare tools or versions only under equivalent conditions;
+- never publish raw secret findings or private repository content.
+
+## Triage cadence
+
+During maintenance mode, group incoming evidence rather than opening a new implementation task for every suggestion.
+
+A reasonable review pass should classify new reports as:
+
+- `confirmed-product-bug`
+- `needs-reproduction`
+- `documentation`
+- `performance-evidence`
+- `workflow-friction`
+- `future-product-signal`
+- `not-actionable-yet`
+
+Repository labels may differ; these are decision categories, not a requirement to create matching labels.
+
+## Gate for the next product version
+
+Do not start a new feature release merely because time has passed.
+
+Open the next product-version planning cycle when at least one of these conditions is met:
+
+- a repeated real-world problem has enough evidence to justify a coherent feature theme;
+- a correctness/security/platform gap requires changes larger than a maintenance patch;
+- benchmark evidence identifies a material, reproducible product limitation;
+- several independently reported workflow gaps point to the same missing capability.
+
+Before implementation, write a short evidence summary linking the supporting issues/Discussions/benchmarks and explicitly state why the work belongs in a new version rather than maintenance.
+
+## What does not trigger a new release by itself
+
+- lint/format cleanup;
+- flaky-test stabilization;
+- CI/ruleset hardening;
+- typo/documentation-only edits;
+- community templates;
+- benchmark methodology documentation with no runtime change;
+- task/evidence bookkeeping.
+
+The default state after `v0.2.2` is therefore: **stable release, active maintenance, evidence first, no release churn**.


### PR DESCRIPTION
## Summary

Formalizes the post-v0.2.2 maintenance/evidence-gathering phase without changing runtime behavior or release state.

### Adds
- Real-world usage feedback issue form
- Benchmark/performance evidence issue form
- `docs/MAINTENANCE_MODE.md` with evidence-first maintenance and next-version gates

### Fixes
- Replaces the broken `.github/ISSUE_TEMPLATE/config.yml` general-documentation link with the repository README
- Adds a direct maintenance-mode policy link to the issue chooser

## Boundaries
- No runtime changes
- No version bump
- No tag/release/npm/Marketplace changes
- `v0.2.2` remains immutable

## Validation focus
- GitHub issue-form schema/rendering
- Markdown/link correctness
- Existing required CI checks
