### PR TITLE
chore(release): v0.3.0 version coupling, CHANGELOG, README shipped rows, extension sync (TASK-0066)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           node -e "
           const pkg=require('./extensions/vscode/package.json');
-          if(pkg.version!=='0.2.2') throw new Error('extension version must be 0.2.2');
+          if(pkg.version!=='0.3.0') throw new Error('extension version must be 0.3.0');
           if(pkg.publisher!=='Cynrath') throw new Error('publisher must be Cynrath');
           if(pkg.displayName!=='ACKit Toolkit') throw new Error('displayName must be ACKit Toolkit');
           if(!pkg.contributes.views.ackit.find(v=>v.id==='ackit.readiness')) throw new Error('ackit.readiness view missing');
@@ -140,9 +140,9 @@ jobs:
       - name: vsce package --no-dependencies
         run: |
           cd extensions/vscode
-          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.2.2.vsix
-          test -f ackit-vscode-0.2.2.vsix
-          ls -lh ackit-vscode-0.2.2.vsix
+          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.3.0.vsix
+          test -f ackit-vscode-0.3.0.vsix
+          ls -lh ackit-vscode-0.3.0.vsix
       - name: VSIX content audit
         run: |
           cd extensions/vscode
@@ -153,12 +153,12 @@ jobs:
           ls -lh images/icon.png
           file images/icon.png
           # check VSIX size <2MB
-          size=$(stat -c%s ackit-vscode-0.2.2.vsix 2>/dev/null || stat -f%z ackit-vscode-0.2.2.vsix)
+          size=$(stat -c%s ackit-vscode-0.3.0.vsix 2>/dev/null || stat -f%z ackit-vscode-0.3.0.vsix)
           echo "VSIX size $size bytes"
           if [ "$size" -gt 2097152 ]; then echo "::error::VSIX >2MB"; exit 1; fi
           # check no secrets in VSIX
-          unzip -l ackit-vscode-0.2.2.vsix | head -20
-          if unzip -p ackit-vscode-0.2.2.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
+          unzip -l ackit-vscode-0.3.0.vsix | head -20
+          if unzip -p ackit-vscode-0.3.0.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
       - name: Icon dimensions
         run: |
           cd extensions/vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,46 @@ All notable changes to ACKit (`@cynrath/agent-context-kit`) are documented in th
 
 This project follows Semantic Versioning.
 
-## [Unreleased]
+## [0.3.0] - 2026-09-02
 
-Workflow, verification, evidence and resumability expansion (unreleased feature line on `feat/workflow-expansion`).
+Workflow, verification, evidence and resumability expansion (minor release; merged from `feat/workflow-expansion` via PR #7). All capabilities are backward compatible — legacy repositories without `workflow:` config or artifact refs keep exact pre-`0.2.2` behavior. The Browser Companion experiment remains paused on its separate branch and is **not** part of this release.
 
 ### Added
 
-- **Workflow engine** (`src/core/workflow/`): three built-in profiles (`quick`/`standard`/`high-risk`) with canonical stage orders and per-stage required artifacts; per-task state under `.ackit/workflow/` (`ackit.workflow.v1`); `ackit workflow set|show|advance|verify` CLI; verify/fix-loop attempt recording with deterministic fail-rewind; declarative lifecycle gates (frozen eight-point list; no executable hooks by schema construction).
-- **Intent artifact** (`src/core/intent/`): committed `docs/intent/` documents (`ackit.intent.v1`), normalization, machine-path-independent fingerprints, secret-gated validation; `ackit intent new|list|show|validate|fingerprint` CLI.
-- **Task reference fields** (additive frontmatter): `intentRef`, `specRefs`, `decisionRefs`, `planRef` (schemaVersion stays 2 — legacy documents parse identically); `task create --intent/--spec/--decision/--plan`; doctor validates references; plan-first git ordering check (advisory).
-- **Checkpoints + resumability** (`src/core/checkpoint/`): `ackit.checkpoint.v1` per-task checkpoints with deterministic work extraction, staleness detection, resume context + handoff pack renderers; `ackit checkpoint create|show|validate|export` + `ackit task resume`; provider-switch scenario proven by tests.
+- **Workflow profiles** (`src/core/workflow/`): three built-in profiles (`quick`/`standard`/`high-risk`) with canonical stage orders and per-stage required artifacts; per-task state under `.ackit/workflow/` (`ackit.workflow.v1`); `ackit workflow set|show|advance|verify` CLI; verify/fix-loop attempt recording with deterministic fail-rewind; declarative lifecycle gates (frozen eight-point list; no executable hooks by schema construction).
+- **Intent artifacts** (`src/core/intent/`): committed `docs/intent/` documents (`ackit.intent.v1`), normalization, machine-path-independent fingerprints, secret-gated validation; `ackit intent new|list|show|validate|fingerprint` CLI.
+- **Task artifact references** (additive frontmatter): `intentRef`, `specRefs`, `decisionRefs`, `planRef` (schemaVersion stays 2 — legacy documents parse identically); `task create --intent/--spec/--decision/--plan`; doctor validates references; plan-first git ordering check (advisory).
+- **Checkpoints + resumability + handoff** (`src/core/checkpoint/`): `ackit.checkpoint.v1` per-task checkpoints with deterministic work extraction, staleness detection, resume context + handoff pack renderers; `ackit checkpoint create|show|validate|export` + `ackit task resume`; provider-switch scenario proven by tests.
 - **Task-aware context packs**: `ackit pack --task <id>` / `--resume` with documented ranking weights (`taskDeclaredScope`, `taskReference`); checkpoint resume section rides the REQ-CTX-001 mechanism.
-- **Evidence contract v2** (`src/core/evidence/`): `ackit.evidence.v2` registry linking acceptance criteria to typed evidence; criteria sync from the task doc (checkbox state is never copied — implementation ≠ verified); `ackit evidence sync|show|verify|validate` CLI; completeness validation with manual-only insufficiency by default.
-- **Independent verification** (`src/core/verification/`): bounded deterministic verification bundle (`ackit.verification-bundle.v1`) embedding intent, workflow, task, evidence, verdicts, checkpoint, implementation surface, verifier role contract; append-only `ackit.verdict.v1` store (PASS | PASS_WITH_WARNINGS | REWORK_REQUIRED | BLOCKED) with forged-criteria/cross-repo/blocking-on-PASS rejection; `ackit verification bundle|record|show` CLI.
-- **Completion gate integration**: workflow-enabled tasks gate completion on evidence completeness, verdict requirements, stage, verification attempts, and blocking drift — `VERIFY failed → completed` is structurally impossible; legacy tasks keep exact pre-expansion behavior; `--force` remains the explicit escape hatch.
+- **Evidence Contract v2** (`src/core/evidence/`): `ackit.evidence.v2` registry linking acceptance criteria to typed evidence; criteria sync from the task doc (checkbox state is never copied — implementation ≠ verified); `ackit evidence sync|show|verify|validate` CLI; completeness validation with manual-only insufficiency by default.
+- **Independent verification bundle/verdict protocol** (`src/core/verification/`): bounded deterministic verification bundle (`ackit.verification-bundle.v1`) embedding intent, workflow, task, evidence, verdicts, checkpoint, implementation surface, verifier role contract; append-only `ackit.verdict.v1` store (PASS | PASS_WITH_WARNINGS | REWORK_REQUIRED | BLOCKED) with forged-criteria/cross-repo/blocking-on-PASS rejection; `ackit verification bundle|record|show` CLI.
+- **Completion-gate enforcement**: workflow-enabled tasks gate completion on evidence completeness, verdict requirements, stage, verification attempts, and blocking drift — `VERIFY failed → completed` is structurally impossible; legacy tasks keep exact pre-expansion behavior; `--force` remains the explicit escape hatch.
 - **Deterministic drift detection** (`src/core/drift/`): eight frozen finding codes; `ackit drift check [--ci]` + managed pre-commit gate (`ackit drift check-active`, no-op without workflow tasks).
-- **Policy v2** (`src/core/policy/tiers.ts`): risk-tiered autonomy (`tier0..tier4 × allow|ask|deny`, deny wins across layers) + review policy on policy documents AND `ackit.yml`; `--force` is a tier2 boundary (deny → `POLICY-TIER-DENIED` exit 4; non-tty ask → deny); `ackit policy check` prints autonomy + review.
+- **Policy v2 risk tiers + review policy** (`src/core/policy/tiers.ts`): risk-tiered autonomy (`tier0..tier4 × allow|ask|deny`, deny wins across layers) + review policy on policy documents AND `ackit.yml`; `--force` is a tier2 boundary (deny → `POLICY-TIER-DENIED` exit 4; non-tty ask → deny); `ackit policy check` prints autonomy + review.
+- **Declarative lifecycle gates**: per-stage required-artifact gates declared in workflow profiles (data-only list; no executable hooks by schema construction).
 - **Role contracts** (`src/core/roles/`, `templates/roles/`): `ackit.role.v1` portable data-only contracts — researcher, architect, implementer, verifier, security-reviewer, documentation-reviewer, release-reviewer; `ackit role list|show|validate` CLI; verifier contract embedded in bundles; repository roles cannot shadow built-ins.
 - **Skills interoperability** (`src/core/skills/project.ts`): deterministic projections to Claude Code (identity), Copilot instructions (derived `applyTo`), and generic layouts; `ackit skills export --provider --out [--force]` with containment and overwrite refusal.
 - **Local execution journal** (`src/core/journal/`): sanitized append-only JSONL (`ackit.execution-journal.v1`) with a CLOSED event-kind list (no conversation/thought/tool-call capture structurally), redaction at construction, deterministic rotation; `ackit journal show|validate`; non-blocking wiring in task/workflow/evidence/verdict/checkpoint/policy paths.
-- **SDK**: focused typed additions to the frozen allowlist (workflow/intent/checkpoint/evidence/verdict/bundle/drift/policy/role functions and stores); contract test updated.
-- **MCP**: six new READ-ONLY tools (`ackit_workflow_status`, `ackit_get_intent`, `ackit_get_checkpoint`, `ackit_verification_bundle`, `ackit_drift_check`, `ackit_list_roles`); the read-only boundary is preserved — state mutation stays CLI-only by explicit decision (ADR-0028).
+- **CLI/SDK/MCP additions**: focused typed additions to the frozen SDK allowlist (workflow/intent/checkpoint/evidence/verdict/bundle/drift/policy/role functions and stores; contract test updated); six new READ-ONLY MCP tools (`ackit_workflow_status`, `ackit_get_intent`, `ackit_get_checkpoint`, `ackit_verification_bundle`, `ackit_drift_check`, `ackit_list_roles`).
 - **Schemas**: `workflow.schema.json`, `intent.schema.json`, `checkpoint.schema.json`, `evidence.schema.json`, `verdict.schema.json`, `verification-bundle.schema.json`, `role.schema.json`, `execution-journal.schema.json`; `ackit.schema.json`/`task.schema.json`/`policy.schema.json` extended additively.
+
+### Compatibility
+
+- Legacy repositories (no `workflow:` config, no artifact refs, no `.ackit/workflow/` state) retain exactly the supported pre-expansion behavior — proven by the legacy-repository integration fixture.
+- No LLM API, cloud service, or network dependency is introduced; the offline-first invariant (no network calls, no telemetry, no uploads in product code) is preserved and enforced by the offline-egress gate.
+- MCP remains within its documented read-only boundary — all state mutation stays CLI-only by explicit decision (ADR-0028).
+
+### Known limitations (non-blocking follow-ups)
+
+- `workflow:` config keys parse and validate but do not yet alter gate behavior.
+- Advance-gate planning-artifact validation remains declaration-based rather than disk-existence based.
+- Checkpoint writes are not yet temp+rename atomic.
+- MCP drift warning/input parity has the documented residual divergence.
+- Browser Companion remains **paused / experimental** on its separate branch and is excluded from this release.
+
+### Security
+
+- Offline-egress invariant extended over the new subsystems (static gate + runtime contract tests); journal redaction at construction; secret-gated intent validation; no new network calls, telemetry, or arbitrary plugin execution.
 
 ## [0.2.2] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACKit — AgentContextKit
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/v/@cynrath/agent-context-kit?label=npm%20v0.2.2&color=0B84FF&style=for-the-badge" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/v/@cynrath/agent-context-kit?label=npm%20v0.3.0&color=0B84FF&style=for-the-badge" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/dt/@cynrath/agent-context-kit?label=downloads&style=for-the-badge&color=00C853" alt="downloads"></a>
   <a href="https://github.com/Cynrath/agent-context-kit"><img src="https://img.shields.io/github/stars/Cynrath/agent-context-kit?label=stars&style=for-the-badge&color=FFB300" alt="stars"></a>
   <a href="https://github.com/Cynrath/agent-context-kit/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Cynrath/agent-context-kit/ci.yml?branch=master&label=CI&style=for-the-badge" alt="CI"></a>
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license"></a>
-  <a href="https://github.com/Cynrath/agent-context-kit/releases/tag/v0.2.2"><img src="https://img.shields.io/badge/release-v0.2.2-9C27B0?style=flat-square" alt="release"></a>
+  <a href="https://github.com/Cynrath/agent-context-kit/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-9C27B0?style=flat-square" alt="release"></a>
   <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/badge/node-%3E%3D22-339933?style=flat-square&logo=node.js" alt="node"></a>
   <img src="https://img.shields.io/badge/offline--first-yes-00ACC1?style=flat-square" alt="offline">
   <img src="https://img.shields.io/badge/deterministic-yes-FF6F00?style=flat-square" alt="deterministic">
@@ -117,16 +117,16 @@ OpenCode, Copilot, Gemini, Cursor, Cline, any MCP-capable agent).
 <tr><td style="border:1px solid #d0d7de; padding:8px;">📦</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Context Packs</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit pack --max-tokens 50000</code></td><td style="border:1px solid #d0d7de; padding:8px;">Weighted deterministic ranking, manifest <code>hash/reason/tokens</code> per file</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔒</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Scanning</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit scan --ci</code></td><td style="border:1px solid #d0d7de; padding:8px;">Secrets/assignments/private keys/connection strings/entropy/absolute-path/CI pinning/drift, redacted evidence, SARIF 2.1.0</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">✅</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Tasks</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit task</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>docs/tasks</code> single-active, <code>[ ]/[~]/[x]/[!]</code>, completion gate, <code>task doctor</code></td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🧭</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Workflows + Intent</strong> <em>(experimental branch)</em></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit workflow set --profile standard</code></td><td style="border:1px solid #d0d7de; padding:8px;">quick/standard/high-risk lifecycles with stage gates (<code>ackit.workflow.v1</code>), committed intent docs with fingerprints (<code>ackit.intent.v1</code>), artifact refs on tasks</td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🧾</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Evidence + Verification</strong> <em>(experimental branch)</em></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit evidence verify … && ackit verification record …</code></td><td style="border:1px solid #d0d7de; padding:8px;">criteria↔proof registry (<code>ackit.evidence.v2</code>), bounded verification bundles for fresh verifiers, append-only <code>ackit.verdict.v1</code> verdicts, completion gate enforcement</td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">⏸️</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Checkpoints + Resume</strong> <em>(experimental branch)</em></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit checkpoint create … && ackit task resume …</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit.checkpoint.v1</code> snapshots, staleness detection, deterministic resume context + handoff packs, task-aware context packs</td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🛰️</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Drift + Policy v2</strong> <em>(experimental branch)</em></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit drift check --ci</code></td><td style="border:1px solid #d0d7de; padding:8px;">8 deterministic finding codes, risk-tiered autonomy (<code>tier0-4 × allow/ask/deny</code>, deny wins) + review policy, declarative lifecycle gates (no executable hooks), portable role contracts</td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧭</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Workflows + Intent</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit workflow set --profile standard</code></td><td style="border:1px solid #d0d7de; padding:8px;">quick/standard/high-risk lifecycles with stage gates (<code>ackit.workflow.v1</code>), committed intent docs with fingerprints (<code>ackit.intent.v1</code>), artifact refs on tasks</td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧾</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Evidence + Verification</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit evidence verify … && ackit verification record …</code></td><td style="border:1px solid #d0d7de; padding:8px;">criteria↔proof registry (<code>ackit.evidence.v2</code>), bounded verification bundles for fresh verifiers, append-only <code>ackit.verdict.v1</code> verdicts, completion gate enforcement</td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">⏸️</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Checkpoints + Resume</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit checkpoint create … && ackit task resume …</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit.checkpoint.v1</code> snapshots, staleness detection, deterministic resume context + handoff packs, task-aware context packs</td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🛰️</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Drift + Policy v2</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit drift check --ci</code></td><td style="border:1px solid #d0d7de; padding:8px;">8 deterministic finding codes, risk-tiered autonomy (<code>tier0-4 × allow/ask/deny</code>, deny wins) + review policy, declarative lifecycle gates (no executable hooks), portable role contracts</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔭</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Watch/Dashboard</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit dashboard</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>scan --watch</code> debounced 400ms + cache; <code>dashboard</code> localhost-only <code>127.0.0.1</code>, <code>CSP</code> + <code>nosniff</code>, <code>/api/*</code> paginated, <code>&lt;50KB</code> vanilla JS</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🩺</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Diagnostics</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit diagnostics bundle</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit.diagnostics.v1</code> + deterministic <code>bundle-manifest.json</code> (<code>sha256</code> + redaction count), 5-secret <code>[REDACTED]</code> proof</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">⚡</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Benchmarks</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>benchmarks/run.mjs</code></td><td style="border:1px solid #d0d7de; padding:8px;">7 deterministic fixtures, 8 metrics (<code>coldScanMs</code>/<code>warmScanMs</code>/<code>incrementalMs</code>/<code>peakRssMb</code>/<code>filesPerSec</code>/<code>packMs</code>/<code>graphMs</code>/<code>cacheHitRatio</code>), median-of-3</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔌</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>SDK v1</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>import { scanRepository } from "@cynrath/agent-context-kit"</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>sideEffects:false</code>, <code>type:module</code>, <code>exports {".","./mcp"}</code>, <code>AbortSignal</code> &lt;200ms, <code>AckitError</code></td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🧩</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>VS Code</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>extensions/vscode</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>0.2.2</code>, <code>cynrath</code>, <code>lints</code> Linters, <code>onStartupFinished</code>, readiness tree + Problems <code>ACKITxxx</code>, <code>&lt;2MB</code> VSIX — <strong>VSIX-ready, not yet Marketplace</strong></td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🤖</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>MCP</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit mcp serve</code></td><td style="border:1px solid #d0d7de; padding:8px;">Official SDK stdio, 9 read-only tools, 5 resources, 4 prompts, <code>InMemoryTransport</code> cancellation</td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧩</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>VS Code</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>extensions/vscode</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>0.3.0</code>, <code>Cynrath</code>, <code>lints</code> Linters, <code>onStartupFinished</code>, readiness tree + Problems <code>ACKITxxx</code>, <code>&lt;2MB</code> VSIX — <strong>Marketplace: <code>Cynrath.ackit-vscode</code></strong></td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🤖</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>MCP</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit mcp serve</code></td><td style="border:1px solid #d0d7de; padding:8px;">Official SDK stdio, 15 read-only tools (incl. workflow status, intent, checkpoint, verification bundle, drift, roles), 5 resources, 4 prompts, <code>InMemoryTransport</code> cancellation</td></tr>
 </tbody>
 </table>
 
@@ -139,11 +139,11 @@ OpenCode, Copilot, Gemini, Cursor, Cline, any MCP-capable agent).
 ```bash
 # global (recommended)
 npm install --global @cynrath/agent-context-kit
-ackit --version  # 0.2.2
+ackit --version  # 0.3.0
 
 # one-shot, pinned
-npx --yes @cynrath/agent-context-kit@0.2.2 --version
-npx --yes @cynrath/agent-context-kit@0.2.2 --help
+npx --yes @cynrath/agent-context-kit@0.3.0 --version
+npx --yes @cynrath/agent-context-kit@0.3.0 --help
 
 # from source
 pnpm install --frozen-lockfile && pnpm build
@@ -183,7 +183,9 @@ ackit dashboard --port 0 --open  # localhost-only
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔭</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit dashboard</code></td><td style="border:1px solid #d0d7de; padding:8px;">Local dashboard (localhost-only by default)</td><td style="border:1px solid #d0d7de; padding:8px;"><code>--host</code> <code>--port</code> <code>--allow-nonlocal</code> <code>--open</code></td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🧩</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit instructions</code></td><td style="border:1px solid #d0d7de; padding:8px;">Instruction graph v2</td><td style="border:1px solid #d0d7de; padding:8px;"><code>--provider</code> <code>--profile</code> <code>--for</code> <code>--explain</code> <code>--json</code></td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">📦</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit pack</code></td><td style="border:1px solid #d0d7de; padding:8px;">Provider-aware context pack</td><td style="border:1px solid #d0d7de; padding:8px;"><code>--max-tokens</code> <code>--profile</code> <code>--include</code> <code>--changed</code></td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🛠️</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit skills</code> / <code>task</code> / <code>policy</code> / <code>config</code></td><td style="border:1px solid #d0d7de; padding:8px;">Skills, task workflow, policy and configuration</td><td style="border:1px solid #d0d7de; padding:8px;"><code>skills list/validate/install</code> · <code>task create/list/start/complete</code> · <code>policy check</code> · <code>config check</code></td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🛠️</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit skills</code> / <code>task</code> / <code>policy</code> / <code>config</code></td><td style="border:1px solid #d0d7de; padding:8px;">Skills, task workflow, policy and configuration</td><td style="border:1px solid #d0d7de; padding:8px;"><code>skills list/validate/install/export</code> · <code>task create/list/start/complete/resume</code> · <code>policy check</code> · <code>config check</code></td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧭</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit workflow</code> / <code>intent</code> / <code>checkpoint</code></td><td style="border:1px solid #d0d7de; padding:8px;">Workflow lifecycles, intent docs, resume</td><td style="border:1px solid #d0d7de; padding:8px;"><code>workflow set/show/advance/verify</code> · <code>intent new/list/show/validate/fingerprint</code> · <code>checkpoint create/show/validate/export</code></td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧾</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit evidence</code> / <code>verification</code> / <code>drift</code> / <code>role</code> / <code>journal</code></td><td style="border:1px solid #d0d7de; padding:8px;">Evidence registry, verifier bundles, drift, roles, journal</td><td style="border:1px solid #d0d7de; padding:8px;"><code>evidence sync/show/verify/validate</code> · <code>verification bundle/record/show</code> · <code>drift check [--ci]</code> · <code>role list/show/validate</code> · <code>journal show/validate</code></td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔧</td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit cache</code> / <code>workspaces</code> / <code>hooks</code> / <code>report</code> / <code>mcp</code></td><td style="border:1px solid #d0d7de; padding:8px;">Utility commands</td><td style="border:1px solid #d0d7de; padding:8px;"><code>cache clean</code> · <code>workspaces</code> · <code>hooks</code> · <code>report serve</code> · <code>mcp serve</code></td></tr>
 </tbody>
 </table>
@@ -253,7 +255,7 @@ More: [`docs/architecture/overview.md`](docs/architecture/overview.md)
 
 ### 🤖 GitHub Action
 
-Official `Cynrath/agent-context-kit@v0.2.2` (SHA-pinned for high-assurance):
+Official `Cynrath/agent-context-kit@v0.3.0` (SHA-pinned for high-assurance):
 
 ```yaml
 permissions:
@@ -263,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
-      - uses: Cynrath/agent-context-kit@v0.2.2
+      - uses: Cynrath/agent-context-kit@v0.3.0
         with:
           command: scan
           args: "--json"
@@ -312,13 +314,13 @@ ESM-only, `sideEffects:false`, `AbortSignal` cancellable, no `process.exit`. Ref
 
 ### 🧩 VS Code
 
-Extension is **implemented and VSIX-ready (`extensions/vscode` `0.2.2`, `<2MB`) but not yet published to Marketplace** — separate `marketplace: yes` checkpoint.
+Extension is **published on the VS Code Marketplace** — [`Cynrath.ackit-vscode`](https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode) (`0.3.0`, `<2MB` VSIX, offline-first, no telemetry).
 
 From source:
 
 ```bash
 pnpm --filter vscode build
-vsce package # → ackit-0.2.2.vsix
+vsce package # → ackit-vscode-0.3.0.vsix
 ```
 
 Features: readiness tree, Problems `ACKITxxx`, graph “instructions for current file”, tasks/policy/optimize, palette `Refresh/Show Graph/Optimize/Diagnostics`, file watcher debounced, no telemetry.
@@ -332,10 +334,10 @@ Guide: [`docs/guides/vscode.md`](docs/guides/vscode.md)
 | Area | Link |
 |---|---|
 | Architecture | [`docs/architecture/overview.md`](docs/architecture/overview.md) |
-| Concepts | `instruction-graph` · `context-budget` · `provider-profiles` · `readiness` |
-| Guides | [`getting-started`](docs/guides/getting-started.md) · [`readiness`](docs/guides/readiness.md) · [`optimize`](docs/guides/optimize.md) · [`provider-profiles`](docs/guides/provider-profiles.md) · [`instruction-graph`](docs/guides/instruction-graph.md) · [`rule-packs`](docs/guides/rule-packs.md) · [`ci`](docs/guides/ci.md) · [`watch-dashboard`](docs/guides/watch-dashboard.md) · [`diagnostics`](docs/guides/diagnostics.md) · [`sdk`](docs/guides/sdk.md) · [`vscode`](docs/guides/vscode.md) · [`monorepo`](docs/guides/monorepo.md) |
-| Reference | `cli` · `config` · `rules` · `readiness` · `profile` · `rule-pack` · `instruction-graph` · `diagnostics` · `sdk` · `exit-codes` · `mcp` · `schemas` |
-| Decisions | [`docs/decisions/`](docs/decisions/) · `v0.2.0`: [`docs/v0.2.0/`](docs/v0.2.0/) |
+| Concepts | `instruction-graph` · `context-budget` · `provider-profiles` · `readiness` · [`workflows`](docs/concepts/workflows.md) · [`intent`](docs/concepts/intent.md) · [`checkpoints`](docs/concepts/checkpoints.md) · [`evidence-verification`](docs/concepts/evidence-verification.md) |
+| Guides | [`getting-started`](docs/guides/getting-started.md) · [`readiness`](docs/guides/readiness.md) · [`optimize`](docs/guides/optimize.md) · [`provider-profiles`](docs/guides/provider-profiles.md) · [`instruction-graph`](docs/guides/instruction-graph.md) · [`rule-packs`](docs/guides/rule-packs.md) · [`ci`](docs/guides/ci.md) · [`watch-dashboard`](docs/guides/watch-dashboard.md) · [`diagnostics`](docs/guides/diagnostics.md) · [`sdk`](docs/guides/sdk.md) · [`vscode`](docs/guides/vscode.md) · [`monorepo`](docs/guides/monorepo.md) · [`workflow-adoption`](docs/guides/workflow-adoption.md) · [`workflow-example`](docs/guides/workflow-example.md) |
+| Reference | `cli` · `config` · `rules` · `readiness` · `profile` · `rule-pack` · `instruction-graph` · `diagnostics` · `sdk` · `exit-codes` · `mcp` · `schemas` · [`drift`](docs/reference/drift.md) · [`policy`](docs/reference/policy.md) |
+| Decisions | [`docs/decisions/`](docs/decisions/) · `v0.2.0`: [`docs/v0.2.0/`](docs/v0.2.0/) · `ADR-0025..0028`: workflow/evidence/checkpoint/policy-v2 |
 | Tasks | [`docs/tasks/active`](docs/tasks/active) |
 
 ---
@@ -369,7 +371,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the docs-first workflow.
 
 ### 🔖 Versioning
 
-Current: **`0.2.2`** on `master` · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases) · `latest → 0.2.2` via OIDC Trusted Publishing with provenance. Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
+Current: **`0.3.0`** on `master` · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases) · `latest → 0.3.0` via OIDC Trusted Publishing with provenance. Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
 
 ---
 

--- a/docs/tasks/active/TASK-0066-v0-3-0-release-version-coupling-changelog-readme.md
+++ b/docs/tasks/active/TASK-0066-v0-3-0-release-version-coupling-changelog-readme.md
@@ -1,0 +1,182 @@
+---
+id: "TASK-0066"
+title: "v0.3.0 release — version coupling, CHANGELOG, README, tag, npm OIDC, VSIX, Action, docs sync, post-release verification"
+status: active
+schemaVersion: 2
+dependencies:
+  []
+createdAt: "2026-09-02"
+completedAt: null
+---
+
+## Purpose
+
+Execute the full logical minor release `v0.3.0` of AgentContextKit (workflow, verification, evidence and resumability expansion merged from PR #7 into `master` at squash commit `5b1f4a0be78d6abeb1e2f26583ac608d4251e2de`), per `ADR-0023` coupling (`root npm 0.3.0 == VS Code extension 0.3.0 == tag v0.3.0 == GitHub Release v0.3.0 == Action @v0.3.0`), with tag-triggered OIDC npm publish + GitHub Release, VSIX Marketplace publication under publisher `Cynrath`, GitHub Action tag availability, hosted docs sync, and complete post-release verification across every established first-party channel.
+
+This task carries explicit user authorization (recorded in the release session goal) for: master merge of PR #7 (done — `5b1f4a0`), version bump, CHANGELOG/README release metadata, release commit push to `master`, annotated tag `v0.3.0` creation + push (triggering tag-only `release.yml` npm OIDC publish + GitHub Release), VSIX `0.3.0` Marketplace publish, hosted docs sync, and post-release verification. Prohibited (unchanged): force-push, history rewrite, tag movement/deletion, workflow dispatch, weakening quality gates, Browser Companion (remains PAUSED/excluded).
+
+## Current-state evidence (verified live 2026-09-02)
+
+- PR #7 (`feat: workflow, verification, evidence and resumability expansion`) squash-merged into `master` at `5b1f4a0be78d6abeb1e2f26583ac608d4251e2de` (mergedAt `2026-09-02T09:29:29Z`), 166 files +18,700 lines. Self-approval attempt rejected by GitHub (`Review Can not approve your own pull request`) — recorded as expected behavior; `protect-master` ruleset requires only the 12 status checks, not independent review. Local `master` == `origin/master` == `5b1f4a0` (fast-forward pull verified).
+- Pre-merge exact-head validation at `737c0b1`: CI run `33593476396` SUCCESS (12/12 required checks: 6 verify OSxNode, 3 package-smoke, self-scan, extension) + ACKit Action Dogfood run `33593476378` SUCCESS.
+- Post-merge master runs at `5b1f4a0`: `ACKit Action Dogfood` run `33614396992` SUCCESS; `CI` run `33614396988` in progress at task creation (must be green before any release step proceeds).
+- Current versions: `package.json` `0.2.2`, `extensions/vscode/package.json` `0.2.2` (coupling holds at 0.2.2; both must move to `0.3.0` together).
+- CHANGELOG.md `## [Unreleased]` section holds the merged feature line content (workflow engine, intent, checkpoints, evidence v2, verification, drift, policy v2, roles, skills, journal, MCP/SDK additions) — needs conversion to `## [0.3.0] - 2026-09-02` with shipped framing.
+- README.md still labels 4 capability rows `(experimental branch)` (Workflows+Intent, Evidence+Verification, Checkpoints+Resume, Drift+Policy v2) — must flip to shipped after merge; limitations (workflow config keys parse-only, advance-gate declaration-based validation, checkpoint non-atomic writes, MCP drift parity divergence, Browser Companion paused) must remain accurately documented.
+- `extensions/vscode/README.md` shows `0.2.2` (needs 0.3.0), `extensions/vscode/CHANGELOG.md` lacks a 0.3.0 entry.
+- npm registry: `@cynrath/agent-context-kit` latest `0.2.2`; `0.3.0` must be verified absent before tag.
+- Tags: `v0.2.2`..`v0.1.0` exist; `v0.3.0` must be verified absent.
+- GitHub Releases: `v0.2.2` latest; `v0.3.0` absent.
+- Marketplace: `Cynrath.ackit-vscode` latest published `0.2.2`; `0.3.0` must be absent until VSIX publish.
+- CI workflow (`.github/workflows/ci.yml` `extension` job) hardcodes extension version `0.2.2` in manifest contract and VSIX filename (`ackit-vscode-0.2.2.vsix`) — must be updated to `0.3.0` in the same synchronized change.
+- `tests/contract/readme-parity.test.ts` asserts README contains `v${pkg.version}` badges — dynamic, will pass after synchronized bump; stale `0.2.2` badge check only guards `npm%20v0.2.0`/`release-v0.2.0` (docs/v0.2.0 path exempt).
+- Established release sequence source: TASK-0039 (v0.2.2 release) — tag-triggered `release.yml` (validate → frozen install → lint/format/typecheck → build+schemas drift gate → tests → pack+shasum → real-tarball smoke → version-absence → OIDC publish `--provenance` → registry verify → fresh isolated consumer → secondary npx → GitHub Release last, notes from `CHANGELOG.md` `## [0.3.0]` via `scripts/extract-changelog-section.mjs`), then `vsce publish` VSIX, then `sync-ackit-docs.mjs` hosted docs, then global install verify.
+
+## Version decision
+
+- **Chosen version: `0.3.0`** (minor). SemVer rationale: PR #7 adds substantial new backward-compatible capabilities (workflow profiles, intent artifacts, checkpoints/resume, evidence v2, verification bundles/verdicts, drift detection, policy v2, roles, skills projections, journal, MCP tools, SDK surface) with no breaking changes — legacy repositories retain exact pre-expansion behavior (proven by `tests/integration/compat/legacy-repository.test.ts`); task schema stays `schemaVersion 2` (additive frontmatter only). Under ADR-0023 one logical release → all surfaces synchronized to `0.3.0`. No version reserved for Browser Companion (paused, excluded from this release).
+
+## Scope
+
+1. Wait for post-merge master CI run `33614396988` (and Dogfood `33614396992`) at `5b1f4a0` to be green; record exact run IDs/conclusions.
+2. Synchronized version bump `0.2.2 → 0.3.0`:
+   - `package.json` `version: "0.3.0"` (single source of truth).
+   - `extensions/vscode/package.json` `version: "0.3.0"` (coupling).
+   - `pnpm-lock.yaml` via `pnpm install` (then `--frozen-lockfile` must pass).
+   - `.github/workflows/ci.yml` extension job: manifest contract `0.2.2` → `0.3.0` (2 occurrences: contract assert + VSIX filename ×2).
+   - `extensions/vscode/README.md` version `0.2.2` → `0.3.0` (header + Changelog link).
+3. CHANGELOG release notes:
+   - `CHANGELOG.md`: convert `## [Unreleased]` → `## [0.3.0] - 2026-09-02` with accurate shipped capabilities (workflows, intent, task refs, checkpoints/resume/handoff, task-aware packs, evidence v2, verification bundles/verdicts, completion gates, drift, policy v2 tiers/review, lifecycle gates, roles, skills interoperability, journal, CLI/SDK/MCP additions, schemas, security/offline guarantees, backward compatibility), explicit Browser Companion exclusion, compatibility facts (legacy repos unchanged, no LLM/cloud dependency, MCP read-only boundary), and the 5 material limitations kept visible.
+   - `extensions/vscode/CHANGELOG.md`: add `## [0.3.0] - 2026-09-02` (workspace dependency on core 0.3.0, manifest version sync, no extension behavior change beyond version).
+4. README post-merge cleanup:
+   - Remove `(experimental branch)` from the 4 now-shipped rows (Workflows + Intent, Evidence + Verification, Checkpoints + Resume, Drift + Policy v2).
+   - Keep the 5 documented limitations accurate (workflow config keys parse but do not alter gate behavior; advance-gate planning artifact validation declaration-based; checkpoint writes not temp+rename atomic; MCP drift warning/input parity residual divergence; Browser Companion PAUSED/experimental, excluded).
+   - Version references `0.2.2` → `0.3.0` (badges, npx examples, Action pin examples, VS Code table, current-status line) while preserving `docs/v0.2.0` historical paths and legacy NuGet notes.
+   - Update "not yet published to Marketplace" phrasing if present to reflect established Marketplace presence (0.2.2 published; 0.3.0 publishing in this task).
+5. Full pre-release gate matrix on the release-candidate commit (repository scripts):
+   - `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm gen:schemas` (+ `git diff --exit-code -- schemas` idempotence), `pnpm build`, `pnpm test`, `pnpm smoke:cli`, `pnpm run smoke:package`, `node scripts/check-offline-egress.mjs`, `node scripts/check-readme-parity.mjs`, `node dist/cli/index.js config check`, `doctor`, `task doctor`, `skills validate`, `instructions`, `scan --ci`, `git diff --check`, `git status`.
+   - Extension gates: `pnpm --filter ackit-vscode exec tsc -p tsconfig.json --noEmit`, `tsconfig.test.json --noEmit`, esbuild build, `vsce ls`, `vsce package --no-dependencies --out ackit-vscode-0.3.0.vsix` (<2MB), VSIX audit (no node_modules/secrets/local paths), icon 256×256.
+   - Expected baseline: 92 files / 517 tests / scan exit 0 (actual values recorded; may legitimately differ due to release-only docs/tests).
+6. Release commit + push (normal fast-forward `master` push), record exact release SHA, wait for all required GitHub Actions on that exact SHA to be green (CI + Dogfood).
+7. Tag: verify `v0.3.0` absent, `npm 0.3.0` absent, Release `v0.3.0` absent → create annotated tag `v0.3.0` on the exact release commit → push tag → tag triggers `release.yml` (npm OIDC publish + GitHub Release, strictly ordered).
+8. Post-npm verification: `npm view` version/dist-tags/latest/shasum/integrity/attestations, fresh isolated consumer (`mktemp` + unique cache, `ackit --version` == `0.3.0`, `--help` leak-free), secondary `npx` smoke.
+9. VS Code Marketplace: `vsce publish --packagePath ackit-vscode-0.3.0.vsix --no-dependencies` under publisher `Cynrath` after npm/GitHub Release green; verify via `vsce show`/Marketplace URL (propagation-aware).
+10. GitHub Action channel: `Cynrath/agent-context-kit@v0.3.0` resolvable via new immutable tag (action listing updates on Release; manual UI fallback documented only if needed); verify Action dogfood on master after tag.
+11. Hosted docs sync: `node scripts/sync-ackit-docs.mjs --source <repo>` → commit on `Cynrath.github.io` `main` → push → verify live pages describe `0.3.0`.
+12. Post-release verification matrix (GitHub / npm / Marketplace / Action / docs) with concrete URLs, run IDs, version numbers; global `ackit` `0.3.0` install smoke.
+13. Post-release maintenance task chain: propose separate follow-up tasks (not executed in this release) for the 5 known non-blocking follow-ups.
+
+## Out of scope
+
+- Browser Companion (PAUSED, separate branch, excluded from release, no code merge, no publish, no version reservation).
+- `workflow:` config keys → actual gate behavior wiring (follow-up).
+- Advance-gate planning artifact disk-existence validation (follow-up).
+- Checkpoint temp+rename atomic writes (follow-up).
+- MCP drift warning/input parity completion (follow-up).
+- Force-push, rebase, tag movement/deletion, `workflow_dispatch`, new distribution channels, new accounts/services.
+- Legacy .NET/NuGet line (frozen; `1.0.0-rc.1` immutable).
+- Moving/creating major/minor alias (moving) tags — no existing policy establishes one; immutable `v0.3.0` only.
+
+## Dependencies
+
+- TASK-0044..0065 (workflow expansion implementation, all completed pre-merge).
+- PR #7 merge (done, `5b1f4a0`).
+- Post-merge master CI green at `5b1f4a0` (in progress at plan time).
+- ADR-0023 (version coupling), ADR-0025..0028 (feature ADRs, content baseline for notes).
+- Previous release execution template: TASK-0039.
+
+## Affected files
+
+- `package.json` (version 0.3.0)
+- `extensions/vscode/package.json` (version 0.3.0)
+- `pnpm-lock.yaml` (if changed by workspace link version)
+- `.github/workflows/ci.yml` (extension job hardcoded 0.2.2 → 0.3.0: manifest contract + VSIX filenames)
+- `CHANGELOG.md` (Unreleased → 0.3.0 dated section)
+- `extensions/vscode/CHANGELOG.md` (add 0.3.0)
+- `extensions/vscode/README.md` (version 0.3.0)
+- `README.md` (badges/examples 0.3.0, experimental-branch rows → shipped, limitations kept accurate)
+- `docs/tasks/active/TASK-0066-*.md` (this task, evidence)
+- Tag `v0.3.0` (annotated, on release commit)
+- GitHub Release `v0.3.0` (auto-created by release.yml from CHANGELOG)
+- npm `@cynrath/agent-context-kit@0.3.0` (OIDC)
+- Marketplace `Cynrath.ackit-vscode` 0.3.0 (VSIX)
+- Hosted docs repo `Cynrath.github.io` `main` (sync script output)
+
+## Required tests
+
+- Full gate matrix in Scope §5 (each command exit 0 recorded with counts: lint/format/typecheck/test file+test counts, smoke CLI assertions, package smoke tarball version, parity SHA, offline-egress file count, scan findings count + exit 0, extension typechecks/build/VSIX audit).
+- Exact release-SHA CI: `CI` workflow + `ACKit Action Dogfood` success on the release commit before tagging.
+- `release.yml` run on tag `v0.3.0`: every step success (validate/frozen/lint/typecheck/build/schemas/tests/pack/smoke/absence/publish/verify/fresh-consumer/npx/release).
+- Registry: `npm view @cynrath/agent-context-kit@0.3.0 version` == `0.3.0`, `dist-tags.latest` == `0.3.0`, shasum == recorded pack, integrity + provenance present.
+- Fresh isolated consumer install + `ackit --version` == `0.3.0` + leak-free `--help`.
+- `gh release view v0.3.0` correct (tag, title, notes body from CHANGELOG section, not draft/prerelease).
+- Marketplace: `vsce show Cynrath.ackit-vscode` / Marketplace URL shows 0.3.0 (propagation-aware retry), extension ID/publisher unchanged.
+- Action: `Cynrath/agent-context-kit@v0.3.0` usable (tag resolvable; dogfood green on master).
+- Docs: live pages describe 0.3.0.
+- Global: `ackit --version` == `0.3.0` after `npm install --global`.
+
+## Acceptance criteria
+
+- [ ] Post-merge master CI + Dogfood green at `5b1f4a0` (run IDs recorded)
+- [ ] Version coupling synchronized: root == extension == 0.3.0; ci.yml extension contract updated; frozen-lockfile install passes
+- [ ] CHANGELOG.md `## [0.3.0] - 2026-09-02` accurate (shipped capabilities, Browser Companion exclusion, compatibility facts, 5 limitations visible); extension CHANGELOG 0.3.0 entry
+- [ ] README shipped rows updated (no stale `(experimental branch)` on shipped features), limitations accurate, all version refs 0.3.0 (historical paths preserved), parity test green
+- [ ] Full local gate matrix green on release-candidate commit (counts recorded)
+- [ ] Release commit pushed; exact-SHA CI + Dogfood green before tag
+- [ ] Annotated immutable tag `v0.3.0` on exact release commit; tag-absence verified pre-creation; never moved
+- [ ] `release.yml` succeeded: npm 0.3.0 published via OIDC with provenance; `latest` → 0.3.0; shasum/integrity verified; fresh consumer + npx smoke green; GitHub Release v0.3.0 created (notes from CHANGELOG, not draft)
+- [ ] VSIX 0.3.0 audited (<2MB, clean contents) and published to Marketplace under `Cynrath`; verified visible
+- [ ] Action `@v0.3.0` resolvable; post-tag dogfood green
+- [ ] Hosted docs synced and live-describing 0.3.0
+- [ ] Global `ackit` 0.3.0 verified
+- [ ] Post-release verification matrix all PASS with concrete URLs/IDs
+- [ ] Post-release maintenance task chain proposed as separate tasks (not mixed into release)
+- [ ] Working tree clean at completion; task completed with evidence; focused conventional commit(s)
+
+## Test steps
+
+1. `gh run list --branch master` — confirm run `33614396988` (CI) and `33614396992` (Dogfood) success at `5b1f4a0`.
+2. Apply synchronized version changes (package.json, extension package.json, ci.yml, extension README, CHANGELOGs, README).
+3. `pnpm install` → `pnpm install --frozen-lockfile` — lockfile consistent.
+4. `pnpm lint && pnpm format:check && pnpm typecheck` — 0 errors.
+5. `pnpm gen:schemas && git diff --exit-code -- schemas` — no drift.
+6. `pnpm build && node dist/cli/index.js --version` — prints `0.3.0`.
+7. `pnpm test` — full suite (expect ≥92 files / ≥517 tests; record actual).
+8. `pnpm smoke:cli && pnpm run smoke:package` — CLI + real-tarball consumer smoke.
+9. `node scripts/check-offline-egress.mjs && node scripts/check-readme-parity.mjs` — security/parity gates.
+10. `node dist/cli/index.js config check && node dist/cli/index.js doctor && node dist/cli/index.js task doctor && node dist/cli/index.js scan --ci` — dogfood gates exit 0.
+11. Extension: `pnpm --filter ackit-vscode exec tsc -p tsconfig.json --noEmit` + test config + esbuild + `vsce package --no-dependencies --out ackit-vscode-0.3.0.vsix` + audit.
+12. `git diff --check && git status --short` — clean; commit; `git push origin master`; wait CI + Dogfood green on new SHA.
+13. Absence checks: `git tag --list v0.3.0` empty, `npm view @cynrath/agent-context-kit@0.3.0` E404, `gh release view v0.3.0` not found, `vsce show` has no 0.3.0.
+14. `git tag -a v0.3.0 -m "AgentContextKit v0.3.0" <release-sha> && git push origin v0.3.0` — triggers release.yml; watch run to success.
+15. Registry/GitHub verification per Required tests; then `vsce publish` VSIX; then docs sync + push; then global install verify.
+16. Post-publish matrix sweep + report.
+
+## Security considerations
+
+- Tag-triggered OIDC Trusted Publishing only (no `NPM_TOKEN`/`NODE_AUTH_TOKEN` secrets; `id-token: write`); tag shape gate `^v\d+\.\d+\.\d+$`; checkout-identity + package-version-name parity enforced in workflow.
+- VSIX audit: no `node_modules`, no secrets (`AKIA`/`ghp_`), no absolute local paths, <2MB, icon 256×256.
+- npm tarball whitelist (`dist`, `templates`, `schemas`, `README.md`, `CHANGELOG.md`, `LICENSE`); README parity SHA recorded; no secrets/local paths in packed artifacts.
+- Offline-egress invariant unchanged (no network/telemetry in product code); extension offline audit stays in CI.
+- No absolute machine paths or secret values in task evidence or release notes.
+
+## Risks
+
+- Post-merge CI at `5b1f4a0` fails → do not proceed to any release step; diagnose, task-first fix, re-run matrix (merge itself stays).
+- `npx` cache stale after publish → fresh isolated consumer is the hard gate (established design; npx is best-effort).
+- Marketplace propagation delay → verify with bounded retries; retry-publish proof ("already exists") as fallback evidence.
+- README parity test expects `v${pkg.version}` dynamically — synchronized bump required before tests run.
+- ci.yml extension contract hardcodes version — missing update fails CI extension job (good gate; must be updated in same change).
+- Version-absence gate refuses republish if 0.3.0 somehow exists → diagnose rather than overwrite; never mutate published versions.
+- Docs sync script requires docs-source paths present post-merge — verify script runs on master content before pushing docs repo.
+
+## Rollback plan
+
+- Before tag: `git revert`/`git checkout HEAD --` the release-prep files (package.json, extension package.json, ci.yml, CHANGELOGs, READMEs) — no public artifact exists yet.
+- After tag push but before release.yml success: tag is immutable once pushed; never move/delete. If release.yml fails pre-publish, npm stays absent — fix forward on master, re-release as new version if needed.
+- After npm publish: never republish same version; any defect → new patch release (0.3.1) per controlled-release governance.
+- Marketplace/docs out of sync after partial failure: publish missing channel, re-verify; never rewrite published immutable history.
+
+## Completion notes
+
+(plan; execution evidence recorded below as steps complete)

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — VS Code Extension
 
+## [0.3.0] - 2026-09-02
+
+- Sync: workspace dependency `@cynrath/agent-context-kit` `workspace:*` now resolves core `0.3.0` (workflow/intent/checkpoint/evidence/verification/drift/policy-v2/roles/skills/journal capabilities in the shared SDK).
+- Sync: manifest `version` `0.2.2 → 0.3.0` per ADR-0023 version coupling (root == extension == tag == release == action).
+- No extension UI behavior change in this release; extension surfaces (Readiness, Findings/Problems, Instruction Graph, Tasks, Policy, Optimize, Diagnostics) operate unchanged on the expanded SDK.
+- Offline-first unchanged: no network, no telemetry, no remote fonts.
+
 ## [0.2.2] - 2026-08-27
 
 - Fix: real TreeDataProvider for `ackit.readiness`/`ackit.findings`/`ackit.graph`/`ackit.tasks`/`ackit.policy`/`ackit.optimize` (previously no providers)

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -3,7 +3,7 @@
 Offline-first agent readiness for your repository — directly inside VS Code.
 
 - **Publisher:** `Cynrath` (`Cynrath.ackit-vscode`)
-- **Version:** `0.2.2`
+- **Version:** `0.3.0`
 - **Engine:** `VS Code ^1.90.0`
 - **Activation:** `onStartupFinished` (debounced, lazy refresh)
 - **Category:** `Linters`
@@ -70,7 +70,7 @@ All commands support multi-root: `getRootForActiveEditor()` → active editor's 
 - Docs: https://cynrath.github.io/agent-context-kit/
 - Guides: https://cynrath.github.io/agent-context-kit/vscode/
 - Marketplace: https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode
-- Changelog: `CHANGELOG.md` (v0.2.2)
+- Changelog: `CHANGELOG.md` (v0.3.0)
 
 ## Screenshots
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ackit-vscode",
   "displayName": "ACKit Toolkit",
   "description": "Offline-first agent readiness toolkit for VS Code",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "publisher": "Cynrath",
   "engines": {
     "vscode": "^1.90.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cynrath/agent-context-kit",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "ACKit turns any repository into an agent-ready repository: instruction graph, agent skills, security scanning, context budgeting, task-first workflow, policy-as-code, and MCP integration. Offline-first and deterministic.",
   "keywords": [
     "ackit",


### PR DESCRIPTION
Release preparation for v0.3.0 (TASK-0066, user-authorized release session):

## Changes
- package.json + extensions/vscode/package.json: version 0.2.2 → 0.3.0 (ADR-0023 coupling: root == extension == tag == release == action)
- .github/workflows/ci.yml: extension manifest contract + VSIX filename 0.2.2 → 0.3.0
- CHANGELOG.md: [Unreleased] → [0.3.0] - 2026-09-02 with shipped capabilities, compatibility facts, 5 known limitations, Browser Companion exclusion
- extensions/vscode/CHANGELOG.md: 0.3.0 sync entry
- README.md: removed (experimental branch) labels from 4 shipped rows, Marketplace published status, version refs 0.2.2 → 0.3.0 (badges/npx/Action/VS Code/current), MCP tools 9 → 15, CLI table + docs map updated with new commands/docs

## Validation (local, exact tree)
- pnpm lint / format:check / typecheck: 0 errors (288 files checked)
- pnpm gen:schemas: idempotent, no diff
- pnpm build: 0.3.0
- pnpm test: 92 files / 517 tests PASS (matches validated baseline)
- pnpm smoke:cli + smoke:package: PASS (cynrath-agent-context-kit-0.3.0.tgz)
- offline-egress: PASS; README parity: PASS (SHA e0fe8452...)
- doctor / task doctor / skills validate / instructions / scan --ci: exit 0
- Extension: tsc x2 PASS, esbuild PASS, vsce ls clean, VSIX 0.3.0 packaged 652704 bytes <2MB, manifest version/publisher/displayName correct, icon 256x256

## Follow-up
After merge: annotated tag v0.3.0 → release.yml (npm OIDC + GitHub Release) → VSIX publish → docs sync → post-release verification (TASK-0066).