### PR TITLE
docs(tasks): freeze v0.5.0 roadmap chain TASK-0078..0086 (plans only, no implementation)

### DIFF
--- a/docs/tasks/active/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
+++ b/docs/tasks/active/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
@@ -1,0 +1,88 @@
+---
+id: "TASK-0078"
+title: "v0.5 baseline and maintenance-aware release-state model"
+status: pending
+schemaVersion: 2
+dependencies:
+  []
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Fix the maintenance-line governance gap left by the v0.4.1 out-of-band maintenance release: current master still reports source version `0.4.0` in `package.json` and hard-codes `0.4.0` release truth in README badges while the latest published stable is `0.4.1`, and `scripts/check-version-parity.mjs` treats `package.json` as the single truth so it PASSES despite the stale default-branch README. Design and land a maintenance-aware release-state model that distinguishes source-checkout/development version, published stable version, historical versions, and maintenance-line versions, and teach the parity guard to understand them as separate concepts. No v0.5.0 publication occurs in this task.
+
+## Current-state evidence (verified live 2026-09-04 on master 725ed18)
+
+- `package.json` version `0.4.0`; `extensions/vscode/package.json` version `0.4.0` (ADR-0023 coupling holds).
+- `npm view @cynrath/agent-context-kit version` → `0.4.1` (latest published stable).
+- README hard-codes `0.4.0`: npm badge label `npm v0.4.0`, release badge `release-v0.4.0` linking `releases/tag/v0.4.0`, VS Code table cell `0.4.0`.
+- `node scripts/check-version-parity.mjs` → PASS (current 0.4.0, 14 files clean): the guard compares current-facing surfaces against `package.json` only, so it cannot see that npm latest (`0.4.1`) has moved past the default branch.
+- `scripts/check-version-parity.mjs` internals: `parseVersion` accepts an optional `-prerelease` suffix; `findStaleRefs` flags only `0.x` refs older than current (older minor, or older patch on same minor); `MUST_SHOW_CURRENT` requires README/getting-started/VS Code README to contain the `current` string verbatim.
+- `release.yml` triggers only on tags `v*.*.*` (tags-only, OIDC); nothing on master publishes.
+- ADR-0023: one logical release (npm + VSIX + Action pin), `package.json` is source-of-truth version, tag points at the commit whose `package.json` version matches.
+- Preferred model IF tooling safely supports it: master source `0.5.0-dev.0` (or repository-approved equivalent), latest published stable `0.4.1`, maintenance line `0.4.x`. Prerelease-suffix support exists in the parity parser but the consequences for `MUST_SHOW_CURRENT` verbatim matching, the `v*.*.*` tag glob, and the release workflow must be audited before adoption. If prerelease development versions are incompatible with established tooling, design the smallest alternative that still prevents `README says 0.4.0 while npm latest is 0.4.1`.
+
+## Scope
+
+- Audit release policy sources: ADR-0023, `scripts/check-version-parity.mjs` (+ contract tests), `release.yml` tag glob and publish path, README/getting-started/VS Code README current-facing claims, CHANGELOG conventions.
+- Define the four version concepts (source/development, published stable, historical, maintenance-line) and where each is recorded and asserted.
+- Implement the smallest model change that closes the gap (candidate directions, decide in-task: prerelease dev version vs stable-pointer file vs split guard concepts; do NOT pre-commit to one before the audit).
+- Update the parity guard and its contract tests to distinguish the concepts; keep historical references passing.
+- Update stale current-facing references per the chosen model (README badges/links at minimum).
+- Record the decision (ADR addendum or new ADR, as appropriate).
+
+## Out of scope
+
+- Any version bump publication, tag creation, npm publish, GitHub Release, Marketplace publish (all prohibited in this task).
+- v0.5.0 feature work (TASK-0079..0086).
+- Merging or deleting `maintenance/v0.4.1`; touching `feat/browser-companion-v0.3` (PAUSED/NO-GO/DO NOT TOUCH).
+- Broad README/docs rewrites beyond release-truth accuracy.
+
+## Dependencies
+
+- None (chain head; every other v0.5.0 task depends on the model it defines).
+
+## Affected files / expected areas
+
+- `scripts/check-version-parity.mjs` + its contract tests
+- `package.json` (only if the chosen model changes the dev version; never a release bump)
+- `README.md`, `docs/guides/getting-started.md`, `extensions/vscode/README.md` (release-truth surfaces)
+- `docs/decisions/` (ADR addendum or new ADR)
+- `docs/tasks/active/TASK-0078-*.md` (this task)
+
+## Acceptance criteria
+
+- [ ] Release-policy audit recorded (ADR-0023, parity script, release workflow, current-facing surfaces, npm latest) with live evidence.
+- [ ] Four version concepts defined, recorded, and asserted in distinct places; no concept conflated.
+- [ ] `README says 0.4.0 while npm latest is 0.4.1` class of staleness is impossible or mechanically detected (proven by positive + negative probes).
+- [ ] Parity guard green on the new model; historical references still pass; contract tests cover each concept.
+- [ ] No tag, publish, release, or version-bump side effects (`git tag --list`, `npm view` unchanged except by design docs).
+- [ ] Decision recorded as ADR addendum/new ADR; task completed through the real gate with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused parity-guard tests, then `pnpm test` (record counts).
+3. `node scripts/check-version-parity.mjs` green; negative probe (reintroduce stale stable pointer) fails the guard.
+4. `node dist/cli/index.js doctor`, `task doctor`, `scan --ci`, `git diff --check`, `git status`.
+5. Verify no tag/publish side effects.
+
+## Security considerations
+
+- No secrets in version surfaces; no network calls added to product code (npm-latest checks stay manual/documented, never in shipped code paths).
+- No weakening of the parity gate to obtain green.
+
+## Risks
+
+- Prerelease dev versions may interact with the `v*.*.*` tag glob or Marketplace/VSIX flows → audit first, smallest alternative if incompatible.
+- Over-engineering a release-train system → keep to four concepts + guard, nothing more.
+
+## Rollback plan
+
+- Focused revert of the model/guard commit(s) on the task branch before merge; after merge, a forward fix (never history rewrite).
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0079-verification-state-binding-and-evidence-provenan.md
+++ b/docs/tasks/active/TASK-0079-verification-state-binding-and-evidence-provenan.md
@@ -1,0 +1,81 @@
+---
+id: "TASK-0079"
+title: "Verification state-binding and evidence provenance contract"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0078"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Close the highest-value remaining trust gap: design a deterministic state-binding contract so a verifier verdict is tied to the exact state it approved. A stale or replayed verdict must not satisfy completion after relevant state changes. Audit/design fingerprint fields such as repository/source revision digest, task fingerprint, intent/plan/spec/decision fingerprint, config/policy digest, evidence registry digest, verification bundle digest, and verdict input digest. Solve deterministic local state binding first; do NOT jump to PKI, blockchain-style identity, or model-identity crypto.
+
+## Consensus basis
+
+Strong multi-auditor consensus (external audits normalized against post-v0.4.1 state; builtin skill parity/force items treated as DONE baseline): evidence/verdict state binding is the agreed MUST and the highest-value remaining trust gap, above any new scanner rule. Disagreements were about mechanism (crypto identity vs local determinism) — this task takes the agreed path: deterministic local state binding first.
+
+## Scope
+
+- Inventory current verification/evidence/verdict stores and their digests/pointers (`src/core/evidence/`, `src/core/verification/`, workflow store, task docs, config/policy resolution).
+- Define the deterministic state-binding contract: exact field list, canonical digest computation (stable serialization, hash choice, redaction boundaries), and where each digest is recorded and checked.
+- Define stale/replay semantics: which state changes invalidate which verdicts, exact error codes, and completion-gate behavior on stale input.
+- Implement the contract in the verification/evidence core with deterministic fixtures (same input/config yields identical digests).
+- Contract + unit + integration tests, including negative tests (mutate one bound field → verdict rejected with the stable error code).
+- Docs: concept + reference updates describing the binding fields and staleness rules.
+
+## Out of scope
+
+- PKI, key management, blockchain-style identity, model/session-identity crypto claims.
+- Verifier independence hardening (TASK-0080 builds on this contract).
+- New scanner rules; LLM-judged semantic drift (explicitly deferred for v0.5.0).
+- Browser Companion, hosted SaaS, cloud RAG/vector DB, model router.
+
+## Dependencies
+
+- TASK-0078 (version/state vocabulary must be stable before digests bind to it).
+
+## Affected files / expected areas
+
+- `src/core/evidence/**`, `src/core/verification/**`, `src/core/workflow/**` (as the audit finds them)
+- `schemas/` (new/changed digest fields) + `pnpm gen:schemas` idempotence
+- `tests/` contract/unit/integration suites for binding + staleness
+- `docs/concepts/`, `docs/reference/` (binding contract docs)
+
+## Acceptance criteria
+
+- [ ] Contract defines the exact bound-field set with canonical digest rules; same input/config deterministically yields identical digests (fixture-proven).
+- [ ] Stale/replayed verdict is rejected by the completion path with a stable error code (negative-proven per bound field class).
+- [ ] Full gates green (`lint`, `format:check`, `typecheck`, `build`, `test` with counts, `gen:schemas` idempotent).
+- [ ] Offline/no-secret invariants hold (`check-offline-egress`, `scan --ci`, text hygiene, `git diff --check`).
+- [ ] Task completed through the real gate with evidence; no quality-gate weakening.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused binding/staleness suites, then `pnpm test` (record counts).
+3. `pnpm gen:schemas` + `git diff --exit-code -- schemas`.
+4. Deterministic digest fixture check (run twice, byte-compare).
+5. Negative probes: mutate each bound field class, confirm rejection + stable error code.
+6. `doctor`, `task doctor`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- Digests must not leak secret values or absolute local paths; redaction boundaries tested.
+- No new network/telemetry; offline-first preserved.
+- Error messages free of internal paths and secret material.
+
+## Risks
+
+- Non-deterministic serialization (key order, timestamps) breaking digest stability → canonical form + frozen fixtures.
+- Over-binding (trivial changes invalidate everything) vs under-binding (real changes pass) → field-class rationale recorded in the contract doc.
+
+## Rollback plan
+
+- Focused revert of contract commit(s) on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0080-verifier-independence-and-replay-staleness-harde.md
+++ b/docs/tasks/active/TASK-0080-verifier-independence-and-replay-staleness-harde.md
@@ -1,0 +1,82 @@
+---
+id: "TASK-0080"
+title: "Verifier independence and replay-staleness hardening"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0078"
+  - "TASK-0079"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Harden what ACKit can actually prove about verification: current `fresh`/verifier metadata is still partly declarative. On top of the TASK-0079 state-binding contract, prove that a verdict references its exact bundle digest, that implementer-produced/self-issued verifier artifacts cannot silently qualify as independent, and that replayed/stale verdicts are rejected — with a cross-process verifier fixture and stable error codes. Do NOT claim cryptographic proof of model/session identity.
+
+## Consensus basis
+
+Strong multi-auditor consensus (MUST): verifier independence is declarative today and must be hardened with structural checks, not identity crypto. Builds directly on the TASK-0079 binding contract (verdict ↔ bundle digest linkage).
+
+## Scope
+
+- Audit current verifier/fresh metadata: what is proven vs declared (bundle references, issuer fields, timestamps, independence markers).
+- Implement structural independence checks: verdict must reference its exact bundle digest (from TASK-0079); self-issued artifacts (same producer as the implementation under review) must be flagged and must not silently satisfy independence requirements.
+- Replay/staleness rejection wired to the TASK-0079 digests with stable error codes.
+- Cross-process verifier fixture: run verifier in a separate process and prove the independence properties end-to-end (no shared-memory trust).
+- Tests: unit (independence predicates), integration (cross-process fixture), negative (self-issued artifact presented as independent → refused with stable code; replayed bundle → refused).
+- Docs: what independence means in ACKit terms and, explicitly, what is NOT claimed (no model/session-identity crypto).
+
+## Out of scope
+
+- Cryptographic proof of model/session identity, PKI, key infrastructure.
+- Changing the TASK-0079 digest contract itself (gaps found → file follow-up against TASK-0079, do not silently fork it).
+- Autonomous verification scheduling/daemons.
+- Browser Companion, hosted control plane, cloud services.
+
+## Dependencies
+
+- TASK-0078 (baseline vocabulary).
+- TASK-0079 (bundle-digest contract this hardening references).
+
+## Affected files / expected areas
+
+- `src/core/verification/**`, verifier/fresh CLI surfaces
+- `schemas/` (verdict/bundle reference fields) + `pnpm gen:schemas` idempotence
+- `tests/` unit + cross-process integration fixture
+- `docs/concepts/`, `docs/reference/` (independence semantics + non-claims)
+
+## Acceptance criteria
+
+- [ ] Every accepted verdict references its exact bundle digest; mismatch is refused with a stable error code (proven).
+- [ ] Self-issued verifier artifacts cannot silently qualify as independent (proven by negative fixture, stable code).
+- [ ] Replay/stale verdict rejected end-to-end via the cross-process fixture.
+- [ ] Documentation states the non-claims (no identity crypto) alongside the proven properties.
+- [ ] Full gates green with counts; offline/scan/hygiene gates hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused independence/replay suites incl. cross-process fixture, then `pnpm test` (record counts).
+3. `pnpm gen:schemas` + `git diff --exit-code -- schemas`.
+4. Negative probes per acceptance criteria (record stable codes).
+5. `doctor`, `task doctor`, `skills validate`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- No identity material collected; no new trust roots introduced implicitly.
+- Fixture uses synthetic values only; no secrets/absolute paths in artifacts.
+- No gate weakening.
+
+## Risks
+
+- Cross-process fixture flakiness on CI (timeouts, Windows process semantics) → generous-but-bounded timeouts, deterministic ports/paths, retry-free assertions.
+- Over-strict independence breaking legitimate single-operator flows → refusal must be explicit and actionable, never silent.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0081-canonical-read-only-status-and-next-actions-proj.md
+++ b/docs/tasks/active/TASK-0081-canonical-read-only-status-and-next-actions-proj.md
@@ -1,0 +1,78 @@
+---
+id: "TASK-0081"
+title: "Canonical read-only status and next-actions projection"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0079"
+  - "TASK-0080"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Give users one canonical read-only status projection so they never have to manually inspect task + workflow + evidence + verdict + drift + checkpoint separately to answer: what am I working on, what blocks completion, what is stale, what should I do next. Prefer `ackit status` (or an equivalent `doctor --task/--next` design if that avoids unnecessary command growth). It must compose existing engines, not create a second workflow engine. Do NOT build an autonomous `ackit run` command that executes/advances everything automatically unless a separate ADR proves it does not violate ACKit's non-autonomous/no-execution boundary.
+
+## Consensus basis
+
+Strong multi-auditor consensus (MUST, but read-only/composed): status consolidation is agreed; the mutating state-machine `ackit run` variant suggested in one audit is explicitly NOT accepted without a boundary-proving ADR.
+
+## Scope
+
+- Design the canonical projection: exact questions answered, source engines composed (task store, workflow store, evidence registry, verdict/bundle state from TASK-0079/0080, drift, checkpoints), staleness surfacing, next-action derivation rules.
+- Decide command shape (`status` vs `doctor --task/--next`) with a written rationale; avoid command growth unless justified.
+- Implement as a pure projection (no state mutation; prove read-only with a mutation spy/fixture test).
+- Wire verification-staleness and completion-blocker output to the TASK-0079/0080 contracts (stable codes surfaced, not redefined).
+- Tests: projection fixtures (composed states → exact rendered output/JSON), read-only proof, staleness display.
+- Docs: reference for the projection; agent-integration notes if surfaces change.
+
+## Out of scope
+
+- Any mutating/autonomous `ackit run` (rejected unless a separate ADR proves boundary compliance; that ADR is not this task).
+- A second workflow engine or duplicated state machine.
+- Write paths in MCP/Action/VS Code projections (TASK-0083 may expose the read model; this task defines it).
+
+## Dependencies
+
+- TASK-0079 (staleness semantics to display).
+- TASK-0080 (independence/replay states to display).
+
+## Affected files / expected areas
+
+- `src/cli/commands/` (status or doctor extension) + composition layer (no new engine)
+- `src/core/**/store*.ts` read paths only
+- `tests/` projection fixtures + read-only proof
+- `docs/reference/cli.md`, `docs/guides/agent-integration.md` (as needed)
+
+## Acceptance criteria
+
+- [ ] One canonical command answers the four questions (working on / blockers / stale / next) for fixture states, in human and JSON forms.
+- [ ] Projection is proven read-only (mutation-spy test green).
+- [ ] Staleness/blocker output reuses TASK-0079/0080 stable codes (no parallel code vocabulary).
+- [ ] No second engine: implementation composes existing stores (reviewable in diff).
+- [ ] Full gates green with counts; offline/scan/hygiene hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused projection suites, then `pnpm test` (record counts).
+3. Read-only proof test + manual `git status` clean after runs against fixtures.
+4. `doctor`, `task doctor`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- Read-only surface must not expose secret values or absolute local paths; redaction consistent with existing commands.
+
+## Risks
+
+- Scope creep into execution/autonomy → the ADR precondition for `run`-like behavior is a hard stop, recorded in-task if proposed.
+- Output churn breaking agent consumers → JSON contract + fixtures.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0082-portable-handoff-hardening-bound-to-verification.md
+++ b/docs/tasks/active/TASK-0082-portable-handoff-hardening-bound-to-verification.md
@@ -1,0 +1,80 @@
+---
+id: "TASK-0082"
+title: "Portable handoff hardening bound to verification state"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0079"
+  - "TASK-0081"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Harden ACKit's existing checkpoint/resume/handoff (do NOT invent a duplicate subsystem): create a v2/extended handoff only if needed to bind task/workflow state, evidence/verdict pointers/digests, staleness state, next-action contract, redaction manifest, and provider-neutral instructions. Same input/config must be deterministic.
+
+## Consensus basis
+
+Strong multi-auditor consensus (SHOULD): checkpoint/resume/handoff already exists and must be extended in place, bound to the new verification state, not replaced.
+
+## Scope
+
+- Audit current checkpoint/resume/handoff coverage vs the binding list (state, evidence/verdict pointers + digests from TASK-0079, staleness, next-action contract from TASK-0081, redaction manifest, provider-neutral instructions).
+- Design the minimal v2/extended handoff delta (new fields/version marker, backward-compatible read of v1 handoffs, or a justified breaking rule with migration).
+- Bind handoff acceptance to verification state: importing a handoff with stale/invalid digests must surface the TASK-0079 stable codes, never silently accept.
+- Determinism: same input/config yields byte-identical handoff (fixture-proven); redaction manifest honored (secret/absolute-path scrub proven).
+- Tests: round-trip (export → import → resume equivalence), stale-handoff refusal, v1 compatibility, determinism fixture, redaction fixture.
+- Docs: handoff format reference + cross-agent resume guide updates.
+
+## Out of scope
+
+- A parallel/duplicate handoff subsystem; breaking v1 reads without a recorded migration.
+- Autonomous execution on import (handoff resumes context, never auto-advances work).
+- Cloud sync/transfer of handoffs.
+
+## Dependencies
+
+- TASK-0079 (digests/pointers and staleness codes to bind).
+- TASK-0081 (next-action contract shape to embed).
+
+## Affected files / expected areas
+
+- `src/core/checkpoint/**`, handoff export/import paths
+- `schemas/` (handoff fields) + `pnpm gen:schemas` idempotence
+- `tests/` round-trip/stale/compat/determinism/redaction suites
+- `docs/guides/`, `docs/reference/` (handoff docs)
+
+## Acceptance criteria
+
+- [ ] Handoff binds the full list (state, evidence/verdict pointers+digests, staleness, next-action contract, redaction manifest, provider-neutral instructions) or records an explicit justified exception per item.
+- [ ] Stale/invalid handoff refused with TASK-0079 stable codes (proven).
+- [ ] Determinism fixture green; v1 handoffs still readable; redaction fixture green.
+- [ ] No duplicate subsystem (diff reviewable as extension).
+- [ ] Full gates green with counts; offline/scan/hygiene hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused handoff suites, then `pnpm test` (record counts).
+3. `pnpm gen:schemas` + `git diff --exit-code -- schemas`.
+4. Cross-process resume proof (export in one process, import in another).
+5. `doctor`, `task doctor`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- Redaction manifest must scrub secrets and absolute local paths; negative fixtures with synthetic secrets.
+- Handoff import validates shape + digests before use (no trust on read).
+
+## Risks
+
+- Format-version sprawl → single version marker, explicit compat table.
+- Over-binding making handoffs brittle across machines → bind content digests, never machine-local paths.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0083-provider-surface-and-integration-parity-audit-an.md
+++ b/docs/tasks/active/TASK-0083-provider-surface-and-integration-parity-audit-an.md
@@ -1,0 +1,76 @@
+---
+id: "TASK-0083"
+title: "Provider-surface and integration parity audit and implementation"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0078"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Extend the now-solved builtin skill ↔ CLI parity (TASK-0077/v0.4.1 DONE baseline) to the next parity problem: provider-surface semantics (Claude Code, Copilot Chat, Copilot coding agent, Copilot review, VS Code agent mode, Gemini CLI, Codex, etc.) and projection parity across CLI, SDK, read-only MCP, GitHub Action, and VS Code. Model differences only where official/current provider behavior materially differs; do not chase provider count for marketing. Prefer machine-readable fixtures/capability tables and `instructions explain`/status projections. Do not create separate engines: expose the same canonical workflow/evidence/verdict/status snapshot through each surface as appropriate.
+
+## Consensus basis
+
+Strong multi-auditor consensus (SHOULD, two linked items): provider-surface parity audit/implementation + CI/Action/VS Code projection parity, both as composition over one canonical model, no new engines.
+
+## Scope
+
+- Audit provider surfaces against official/current provider behavior: build a capability table (surface × instruction/skill/projection behavior), grounded in primary sources with dates; record where behavior does NOT materially differ (no modeling there).
+- Machine-readable fixtures for material differences; `instructions explain`-style surfacing where it exists.
+- Audit CLI/SDK/MCP/Action/VS Code projections of workflow/evidence/verdict/status (TASK-0081 model) for drift; close proven drift so all surfaces expose the same canonical snapshot.
+- Tests: fixture-driven parity tests per surface; contract tests pinning the capability table; no live-provider calls in tests (offline-first).
+- Docs: provider notes with source + freshness dates; projection parity statement per surface.
+
+## Out of scope
+
+- New provider integrations for marketing breadth; any provider behavior modeled without a primary source.
+- Separate per-surface engines or duplicated workflow logic.
+- MCP mutation/write control plane (explicitly deferred for v0.5.0; MCP stays read-only).
+- Large new builtin-skill catalog (explicitly deferred).
+
+## Dependencies
+
+- TASK-0078 (baseline vocabulary; capability table references stable concepts).
+
+## Affected files / expected areas
+
+- Instruction/skill projection layers, `instructions` command surfaces
+- SDK/MCP/Action/VS Code projection code (as the audit finds drift)
+- `tests/` fixture-driven parity suites + capability-table contract tests
+- `docs/guides/agent-integration.md`, provider notes, `docs/reference/` (as needed)
+
+## Acceptance criteria
+
+- [ ] Capability table covers the listed surfaces, each material difference cites an official/current primary source with date; non-differences explicitly recorded as such.
+- [ ] Proven projection drift closed; all surfaces expose the same canonical snapshot (fixture-proven per surface).
+- [ ] No new engines; MCP remains read-only (offline-egress + capability review).
+- [ ] Full gates green with counts; offline/scan/hygiene hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Focused parity suites, then `pnpm test` (record counts).
+3. Fixture review: each case traces to a table row + source.
+4. `doctor`, `task doctor`, `skills validate`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- No provider credentials, tokens, or live calls in repo/tests; fixtures synthetic.
+- MCP scope unchanged (read-only); any mutation-shaped proposal is out of scope by default.
+
+## Risks
+
+- Provider docs churn → source dates + contract tests pin expectations; refresh is a deliberate follow-up, not drift.
+- Marketing-count pressure → the material-difference rule is the gate; enforce it in review.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0084-security-adversarial-audit-and-proven-gap-repair.md
+++ b/docs/tasks/active/TASK-0084-security-adversarial-audit-and-proven-gap-repair.md
@@ -1,0 +1,77 @@
+---
+id: "TASK-0084"
+title: "Security adversarial audit and proven-gap repairs"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0078"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Settle the contested MCP path allow-list proposal with evidence, not assumption: run a focused adversarial audit of path containment (absolute path, `../` traversal, symlink escape, Windows junction/case behavior, repo root boundary, MCP read paths) against ACKit's claimed realpath containment, root-escape refusal, read-only MCP, and offline/no-network posture. If a real gap is proven, fix it. If containment already blocks the scenario, record the negative finding and do NOT add redundant configuration.
+
+## Consensus basis
+
+Single-report proposal (MUST in one audit) contested by the product-boundary weighting rule: a new MCP path allow-list must not be accepted without a live source audit. Current claimed posture (realpath containment, root-escape refusal, read-only MCP, offline) is the baseline to attack.
+
+## Scope
+
+- Adversarial matrix, each case executed live against the built CLI/MCP: absolute path inputs, `../` traversal at multiple depths, symlink escape (file + dir), Windows junction/case-insensitivity behavior, repo-root boundary (at root, above root), MCP read-path equivalents of each.
+- For each case: ATTACK (exact command/fixture) → RESULT (allowed/refused + exact code/message) → VERDICT (gap or contained, with source line citations).
+- Proven gaps only: minimal fix + regression test per gap; re-run the full matrix after each fix.
+- Negative findings recorded with the same rigor (what was tried, what blocked it, where).
+- Explicit allow-list decision: adopt if and only if the matrix proves containment insufficient; otherwise record why the allow-list is redundant.
+
+## Out of scope
+
+- Preventive allow-list (or any new config surface) without a proven gap.
+- MCP mutation/write paths (none exist; MCP stays read-only; out of scope by product boundary).
+- Network/telemetry additions; cloud-backed analysis.
+- Unrelated hardening beyond the matrix.
+
+## Dependencies
+
+- TASK-0078 (baseline only; audit itself is independent of feature tasks).
+
+## Affected files / expected areas
+
+- Containment/read-path code under `src/core/filesystem/`, MCP server read paths (as the audit finds them)
+- `tests/` adversarial suites (per-case attack fixtures + assertions)
+- Threat-model/ADR note recording the matrix + allow-list decision
+- `docs/` security notes (only what the findings change)
+
+## Acceptance criteria
+
+- [ ] Full attack matrix executed live with ATTACK→RESULT→VERDICT rows and source citations; no case hand-waved.
+- [ ] Every proven gap has a minimal fix + regression test; matrix re-run green after fixes.
+- [ ] Every contained case has a recorded negative finding; allow-list decision (adopt/reject) follows the evidence.
+- [ ] No redundant configuration added on contained findings.
+- [ ] Full gates green with counts; offline/scan/hygiene hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Adversarial suites (Windows semantics included), then `pnpm test` (record counts).
+3. Manual attack spot-checks against `dist/` CLI for each matrix row (record exit codes/messages).
+4. `node scripts/check-offline-egress.mjs`, `scan --ci`, `doctor`, `task doctor`, `git diff --check`.
+
+## Security considerations
+
+- Attack fixtures use synthetic paths/values only; no real user directories touched (isolated temp roots).
+- Findings must not include absolute local paths or machine-identifying details in committed artifacts.
+
+## Risks
+
+- Platform-specific escapes (junctions, case folding) not reproducible on all CI OSes → OS-tagged cases + CI matrix coverage where the repo already runs (ubuntu/windows/macos).
+- Fix overreach (breaking legitimate workflows) → minimal patches + existing-suite green as gate.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0085-product-positioning-and-reproducible-verificatio.md
+++ b/docs/tasks/active/TASK-0085-product-positioning-and-reproducible-verificatio.md
@@ -1,0 +1,79 @@
+---
+id: "TASK-0085"
+title: "Product positioning and reproducible verification-handoff demo"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0081"
+  - "TASK-0082"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Retell ACKit's public story around its differentiated core — provider-independent repository contract, evidence-backed completion, independent verification, deterministic drift, resumable cross-agent handoff, offline/no API key — instead of merely AGENTS.md management, context packing, and scan. Ship a reproducible public demo proving the trust flow with exact deterministic fixtures and measured output: agent/task claims done → completion blocked because proof/verdict is missing/stale → proof/verifier registered → completion succeeds → checkpoint/handoff resumes in another process/provider-neutral flow. No unverified competitor marketing claims.
+
+## Consensus basis
+
+Strong multi-auditor consensus: positioning agreement plus a docs/positioning task with a reproducible verification-handoff demo in the v0.5 chain.
+
+## Scope
+
+- Positioning pass over current-facing docs (README story, guides entry points): lead with contract/evidence/verification/drift/handoff/offline; keep scan/pack content accurate but secondary. No unverified competitor claims; every comparative sentence must cite a primary source or be cut.
+- Reproducible demo: deterministic fixtures + scripted command sequence + recorded exact outputs demonstrating the five-stage flow (claim → blocked → proof registered → completion → cross-process/provider-neutral resume). The demo must run green from a clean checkout (documented prerequisites only).
+- Demo asserts the TASK-0079/0080/0081/0082 behaviors it exercises (stale-block code, digest match, handoff resume equivalence) rather than narrating them.
+- Tests: demo-as-test (the scripted flow runs in CI or as a checked script with pinned outputs); link/content checks for touched docs.
+- Unless the workflow skill cannot remain coherent after progressive disclosure, no new evidence-authoring skill (explicitly deferred otherwise).
+
+## Out of scope
+
+- Competitor feature/marketing claims without primary sources.
+- New builtin-skill catalog or new evidence-authoring skill (deferred; needs the coherence proof first).
+- Hosted demo infrastructure, videos, or website redesign.
+- Browser Companion, SaaS, cloud anything.
+
+## Dependencies
+
+- TASK-0081 (status/next-action semantics the demo narrates).
+- TASK-0082 (handoff resume the demo performs cross-process).
+
+## Affected files / expected areas
+
+- `README.md`, `docs/guides/**` (positioning pass; release-truth lines stay under TASK-0078's model)
+- Demo fixtures + script (new, deterministic; location per repo conventions)
+- `tests/` demo-as-test wiring
+- `templates/skills/ackit-workflow/**` (only if the demo exposes a coherence gap; otherwise untouched)
+
+## Acceptance criteria
+
+- [ ] Current-facing story leads with the six differentiated claims; zero unverified competitor claims (review-proven).
+- [ ] Demo runs green from a clean checkout with exact recorded outputs; all five stages observed.
+- [ ] Demo asserts (not narrates) the underlying contracts: stale-block code, digest match, resume equivalence.
+- [ ] Touched docs pass link/content checks; TASK-0078 release-truth model not violated.
+- [ ] Full gates green with counts; offline/scan/hygiene hold; real-gate completion with evidence.
+
+## Test steps
+
+1. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+2. Demo script from clean fixture (record wall output + exit codes per stage).
+3. `pnpm test` incl. demo-as-test (record counts).
+4. `doctor`, `task doctor`, `scan --ci`, `git diff --check`.
+
+## Security considerations
+
+- Demo fixtures synthetic only; outputs scrubbed of absolute local paths before being recorded.
+- No network calls in the demo path (offline claim must hold while demonstrating).
+
+## Risks
+
+- Demo bit-rot as contracts evolve → demo-as-test pins it; any contract change must update the demo in the same commit.
+- Positioning overreach → every claim traces to shipped behavior + evidence.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix.
+
+## Completion notes
+
+(placeholder)

--- a/docs/tasks/active/TASK-0086-v0-5-0-final-integration-fresh-verifier-and-rele.md
+++ b/docs/tasks/active/TASK-0086-v0-5-0-final-integration-fresh-verifier-and-rele.md
@@ -1,0 +1,107 @@
+---
+id: "TASK-0086"
+title: "v0.5.0 final integration, fresh verifier, and release-readiness"
+status: pending
+schemaVersion: 2
+dependencies:
+  - "TASK-0078"
+  - "TASK-0079"
+  - "TASK-0080"
+  - "TASK-0081"
+  - "TASK-0082"
+  - "TASK-0083"
+  - "TASK-0084"
+  - "TASK-0085"
+createdAt: "2026-09-04"
+completedAt: null
+---
+
+## Purpose
+
+Integrate the full v0.5.0 chain, prove the chain composes (status projection over bound verification state, handoff resume across processes, parity surfaces agreeing), and establish release-readiness with an independent fresh verifier (zero blockers) — without publishing, tagging, or releasing anything. This task definitionally cannot complete while any child task (TASK-0078..0085) has missing acceptance evidence, pending tests, deferred mandatory scope, TODOs, disabled quality gates, unresolved security findings, failed live verification, or missing CI evidence.
+
+## External-audit synthesis (basis for the frozen chain; normalized 2026-09-04)
+
+Source audits (pre-v0.4.1 reports normalized against post-v0.4.1 live state; source files not on disk — synthesis basis is the session consensus plus live verification): GPT-5.6 Sol, Claude Sonnet 5, GLM-5.3-Flash (no web access; lower factual weight), Grok 4.5, Qwen, and one Manus-supplied report self-identifying as "OpenAI / API model" with exact model ID unavailable (two uploaded Manus text files were duplicates and count as ONE audit; the self-reported provider string is not an independently verified official model identity). Weighting: live repo inspection quality, primary-source freshness, architecture agreement, already-fixed status, product-boundary preservation.
+
+| Recommendation | Auditors supporting | Already solved? | v0.5 decision |
+|---|---|---|---|
+| Builtin skill stale-command fixes | Multiple (baseline) | YES (TASK-0077/v0.4.1) | DONE baseline, no work |
+| Basic SKILL↔CLI parity | Multiple (baseline) | YES (parity suite) | DONE baseline, no work |
+| Skills `--force` wiring | Maintenance-driven | YES (v0.4.1 + forward-port) | DONE baseline, no work |
+| Evidence/verdict state binding | Strong consensus | NO | MUST → TASK-0079 |
+| Verifier independence hardening | Strong consensus | NO | MUST → TASK-0080 |
+| Read-only status consolidation | Strong consensus | NO | MUST (composed) → TASK-0081; mutating `ackit run` NOT accepted (Qwen variant rejected without boundary ADR) |
+| Portable handoff hardening | Strong consensus | Partial (v1 exists) | SHOULD (extend v1) → TASK-0082 |
+| Provider-surface parity | Strong consensus | NO (skill↔CLI only) | SHOULD (material differences only) → TASK-0083 |
+| CI/Action/VS Code projection parity | Strong consensus | NO | SHOULD (no new engines) → TASK-0083 |
+| MCP path allow-list | Single report (MUST claim) | UNPROVEN (containment claimed) | Audit first → TASK-0084; adopt only on proven gap |
+| Product positioning + demo | Strong consensus | NO | Docs task → TASK-0085 |
+| Browser Companion revival | None in scope | N/A (PAUSED) | DEFERRED, branch untouched |
+| Hosted SaaS/control plane | None (boundary) | N/A | REJECTED for v0.5.0 |
+| Model router / LLM gateway | None (boundary) | N/A | REJECTED for v0.5.0 |
+| Cloud RAG / vector DB | None (boundary) | N/A | REJECTED for v0.5.0 |
+| LLM-judged semantic drift | None (boundary) | N/A | REJECTED for v0.5.0 |
+| MCP mutation/write control plane | None (boundary) | N/A | REJECTED for v0.5.0 |
+| Generic workflow DSL | None (boundary) | N/A | REJECTED for v0.5.0 |
+| Internal autonomous subagent runtime | None (boundary) | N/A | REJECTED for v0.5.0 |
+| Large new builtin-skill catalog | None (deferred) | N/A | REJECTED for v0.5.0 |
+| New evidence-authoring skill | Conditional | N/A | DEFERRED unless workflow skill incoherent after progressive disclosure |
+
+## Scope
+
+- Integration proof across the chain: status projection (0081) over bound verification state (0079/0080), handoff export→import→resume across processes (0082), parity surfaces agreeing (0083), demo flow green on final code (0085), adversarial matrix green (0084), release-truth model holding (0078).
+- Fresh independent verifier with zero blockers over the whole chain (separate agent/process, read-only, exact-head CI required first).
+- Release-readiness checklist: full gates, version-parity under the new model, CHANGELOG discipline (no premature v0.5.0 entry content beyond an Unreleased scaffold if convention allows), tag/publish absence proof.
+- Docs: chain completion record; v0.5.0 readiness statement with evidence links.
+- No tag, no publish, no release, no deployment in this task.
+
+## Out of scope
+
+- v0.5.0 publication/tag/release (separate user-authorized release task, not this session).
+- Feature implementation beyond integration glue proven necessary by the verifier.
+- All §13 deferred/rejected items (list above); Browser Companion untouched.
+
+## Dependencies
+
+- TASK-0078, TASK-0079, TASK-0080, TASK-0081, TASK-0082, TASK-0083, TASK-0084, TASK-0085 (all must be completed with evidence first).
+
+## Affected files / expected areas
+
+- Integration glue only (as proven necessary) + fixtures
+- `tests/` chain-level integration suites
+- `docs/tasks/active/TASK-0086-*.md` (this task) + readiness record
+- Never: `dist/`, `.ackit/`, artifacts, secrets
+
+## Acceptance criteria
+
+- [ ] Every dependency completed with real evidence; GO-gate scan finds no missing evidence, pending tests, TODOs, weakened gates, or unresolved security findings.
+- [ ] Chain composition proven end-to-end (status over bound state, cross-process handoff resume, surfaces agreeing, demo green, matrix green).
+- [ ] Fresh independent verifier: OVERALL PASS, zero blockers, exact-head CI green recorded.
+- [ ] No tag/publish/release side effects proven (`git tag`, `npm view`, `gh release` unchanged).
+- [ ] Full gates green with counts; task completed through the real gate.
+
+## Test steps
+
+1. Dependency evidence audit (per-task completion notes + CI runs).
+2. `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`.
+3. `pnpm test` full suite (record counts) + `pnpm gen:schemas` idempotence.
+4. `pnpm smoke:cli`, `pnpm run smoke:package`.
+5. Fresh verifier bundle/record/show (zero blockers).
+6. `doctor`, `task doctor`, `skills validate`, `scan --ci`, `git diff --check`, no-publish proof.
+
+## Security considerations
+
+- Integration must not weaken any per-task security property; re-run offline-egress + adversarial spot checks at chain level.
+
+## Risks
+
+- Late-found cross-task contract mismatch → integration glue stays minimal; real mismatches file back against the owning task instead of being papered over here.
+
+## Rollback plan
+
+- Focused revert on the task branch before merge; after merge, forward fix. No release to roll back (nothing published).
+
+## Completion notes
+
+(placeholder)


### PR DESCRIPTION
## Summary

Freezes the v0.5.0 task roadmap from the normalized external audits: nine real CLI-allocated tasks (TASK-0078..0086) with complete plans and a validated dependency graph. Docs-only — no implementation, no version edits, no tag/publish/release.

Chain:

- TASK-0078 v0.5 baseline / maintenance-aware release-state model (chain head; includes live release-policy audit: package 0.4.0 vs npm latest 0.4.1 vs stale README badges vs passing parity guard)
- TASK-0079 verification state-binding / evidence provenance contract (MUST)
- TASK-0080 verifier independence + replay/staleness hardening (MUST)
- TASK-0081 canonical read-only status / next-actions projection (MUST, composed; mutating `ackit run` NOT accepted)
- TASK-0082 portable handoff hardening bound to verification state (SHOULD, extends v1)
- TASK-0083 provider-surface + integration parity audit/implementation (SHOULD, no new engines, MCP stays read-only)
- TASK-0084 security adversarial audit and proven-gap repairs (adopt allow-list only on proven gap)
- TASK-0085 product positioning / reproducible verification-handoff demo
- TASK-0086 final integration, fresh verifier, release-readiness (carries the full audit synthesis table + deferred/rejected list)

## Verification (on branch head)

- `task doctor` → integrity OK (deps acyclic, all known)
- `check-text-hygiene --repo` → clean (897 files)
- `git diff --check` → clean
- Real IDs via `ackit task create`; every plan has purpose, scope, out of scope, dependencies, affected files, acceptance criteria, test steps, security considerations, risks, rollback; completion notes are `(placeholder)` (nothing implemented yet — honest pending state)

## Merge plan

Squash-merge after exact-head CI green. Post-merge: delete the branch locally and remotely. Feature implementation starts only on user request after roadmap review.
