### PR TITLE
feat(release-state): maintenance-aware split release-state model (TASK-0078)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           node -e "
           const pkg=require('./extensions/vscode/package.json');
-          if(pkg.version!=='0.4.0') throw new Error('extension version must be 0.4.0');
+          if(pkg.version!=='0.5.0-dev.0') throw new Error('extension version must be 0.5.0-dev.0');
           if(pkg.publisher!=='Cynrath') throw new Error('publisher must be Cynrath');
           if(pkg.displayName!=='ACKit Toolkit') throw new Error('displayName must be ACKit Toolkit');
           if(!pkg.contributes.views.ackit.find(v=>v.id==='ackit.readiness')) throw new Error('ackit.readiness view missing');
@@ -142,9 +142,9 @@ jobs:
       - name: vsce package --no-dependencies
         run: |
           cd extensions/vscode
-          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.4.0.vsix
-          test -f ackit-vscode-0.4.0.vsix
-          ls -lh ackit-vscode-0.4.0.vsix
+          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.5.0-dev.0.vsix
+          test -f ackit-vscode-0.5.0-dev.0.vsix
+          ls -lh ackit-vscode-0.5.0-dev.0.vsix
       - name: VSIX content audit
         run: |
           cd extensions/vscode
@@ -155,12 +155,12 @@ jobs:
           ls -lh images/icon.png
           file images/icon.png
           # check VSIX size <2MB
-          size=$(stat -c%s ackit-vscode-0.4.0.vsix 2>/dev/null || stat -f%z ackit-vscode-0.4.0.vsix)
+          size=$(stat -c%s ackit-vscode-0.5.0-dev.0.vsix 2>/dev/null || stat -f%z ackit-vscode-0.5.0-dev.0.vsix)
           echo "VSIX size $size bytes"
           if [ "$size" -gt 2097152 ]; then echo "::error::VSIX >2MB"; exit 1; fi
           # check no secrets in VSIX
-          unzip -l ackit-vscode-0.4.0.vsix | head -20
-          if unzip -p ackit-vscode-0.4.0.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
+          unzip -l ackit-vscode-0.5.0-dev.0.vsix | head -20
+          if unzip -p ackit-vscode-0.5.0-dev.0.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
       - name: Icon dimensions
         run: |
           cd extensions/vscode

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ACKit — AgentContextKit
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/v/@cynrath/agent-context-kit?label=npm%20v0.4.0&color=0B84FF&style=for-the-badge" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/v/@cynrath/agent-context-kit?label=npm&color=0B84FF&style=for-the-badge" alt="npm version"></a>
   <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/npm/dt/@cynrath/agent-context-kit?label=downloads&style=for-the-badge&color=00C853" alt="downloads"></a>
   <a href="https://github.com/Cynrath/agent-context-kit"><img src="https://img.shields.io/github/stars/Cynrath/agent-context-kit?label=stars&style=for-the-badge&color=FFB300" alt="stars"></a>
   <a href="https://github.com/Cynrath/agent-context-kit/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Cynrath/agent-context-kit/ci.yml?branch=master&label=CI&style=for-the-badge" alt="CI"></a>
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="license"></a>
-  <a href="https://github.com/Cynrath/agent-context-kit/releases/tag/v0.4.0"><img src="https://img.shields.io/badge/release-v0.4.0-9C27B0?style=flat-square" alt="release"></a>
+  <a href="https://github.com/Cynrath/agent-context-kit/releases/latest"><img src="https://img.shields.io/github/v/release/Cynrath/agent-context-kit?label=release&style=flat-square" alt="release"></a>
   <a href="https://www.npmjs.com/package/@cynrath/agent-context-kit"><img src="https://img.shields.io/badge/node-%3E%3D22-339933?style=flat-square&logo=node.js" alt="node"></a>
   <img src="https://img.shields.io/badge/offline--first-yes-00ACC1?style=flat-square" alt="offline">
   <img src="https://img.shields.io/badge/deterministic-yes-FF6F00?style=flat-square" alt="deterministic">
@@ -125,7 +125,7 @@ OpenCode, Copilot, Gemini, Cursor, Cline, any MCP-capable agent).
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🩺</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Diagnostics</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit diagnostics bundle</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit.diagnostics.v1</code> + deterministic <code>bundle-manifest.json</code> (<code>sha256</code> + redaction count), 5-secret <code>[REDACTED]</code> proof</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">⚡</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>Benchmarks</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>benchmarks/run.mjs</code></td><td style="border:1px solid #d0d7de; padding:8px;">7 deterministic fixtures, 8 metrics (<code>coldScanMs</code>/<code>warmScanMs</code>/<code>incrementalMs</code>/<code>peakRssMb</code>/<code>filesPerSec</code>/<code>packMs</code>/<code>graphMs</code>/<code>cacheHitRatio</code>), median-of-3</td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🔌</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>SDK v1</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>import { scanRepository } from "@cynrath/agent-context-kit"</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>sideEffects:false</code>, <code>type:module</code>, <code>exports {".","./mcp"}</code>, <code>AbortSignal</code> &lt;200ms, <code>AckitError</code></td></tr>
-<tr><td style="border:1px solid #d0d7de; padding:8px;">🧩</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>VS Code</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>extensions/vscode</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>0.4.0</code>, <code>Cynrath</code>, <code>lints</code> Linters, <code>onStartupFinished</code>, readiness tree + Problems <code>ACKITxxx</code>, <code>&lt;2MB</code> VSIX — <strong>Marketplace: <code>Cynrath.ackit-vscode</code></strong></td></tr>
+<tr><td style="border:1px solid #d0d7de; padding:8px;">🧩</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>VS Code</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>extensions/vscode</code></td><td style="border:1px solid #d0d7de; padding:8px;"><code>0.4.1</code>, <code>Cynrath</code>, <code>lints</code> Linters, <code>onStartupFinished</code>, readiness tree + Problems <code>ACKITxxx</code>, <code>&lt;2MB</code> VSIX — <strong>Marketplace: <code>Cynrath.ackit-vscode</code></strong></td></tr>
 <tr><td style="border:1px solid #d0d7de; padding:8px;">🤖</td><td style="border:1px solid #d0d7de; padding:8px;"><strong>MCP</strong></td><td style="border:1px solid #d0d7de; padding:8px;"><code>ackit mcp serve</code></td><td style="border:1px solid #d0d7de; padding:8px;">Official SDK stdio, 15 read-only tools (incl. workflow status, intent, checkpoint, verification bundle, drift, roles), 5 resources, 4 prompts, <code>InMemoryTransport</code> cancellation</td></tr>
 </tbody>
 </table>
@@ -139,11 +139,11 @@ OpenCode, Copilot, Gemini, Cursor, Cline, any MCP-capable agent).
 ```bash
 # global (recommended)
 npm install --global @cynrath/agent-context-kit
-ackit --version  # 0.4.0
+ackit --version  # 0.4.1
 
 # one-shot, pinned
-npx --yes @cynrath/agent-context-kit@0.4.0 --version
-npx --yes @cynrath/agent-context-kit@0.4.0 --help
+npx --yes @cynrath/agent-context-kit@0.4.1 --version
+npx --yes @cynrath/agent-context-kit@0.4.1 --help
 
 # from source
 pnpm install --frozen-lockfile && pnpm build
@@ -255,7 +255,7 @@ More: [`docs/architecture/overview.md`](docs/architecture/overview.md)
 
 ### 🤖 GitHub Action
 
-Official `Cynrath/agent-context-kit@v0.4.0` (SHA-pinned for high-assurance):
+Official `Cynrath/agent-context-kit@v0.4.1` (SHA-pinned for high-assurance):
 
 ```yaml
 permissions:
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
-      - uses: Cynrath/agent-context-kit@v0.4.0
+      - uses: Cynrath/agent-context-kit@v0.4.1
         with:
           command: scan
           args: "--json"
@@ -314,13 +314,13 @@ ESM-only, `sideEffects:false`, `AbortSignal` cancellable, no `process.exit`. Ref
 
 ### 🧩 VS Code
 
-Extension is **published on the VS Code Marketplace** — [`Cynrath.ackit-vscode`](https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode) (`0.4.0`, `<2MB` VSIX, offline-first, no telemetry).
+Extension is **published on the VS Code Marketplace** — [`Cynrath.ackit-vscode`](https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode) (`0.4.1`, `<2MB` VSIX, offline-first, no telemetry).
 
 From source:
 
 ```bash
 pnpm --filter vscode build
-vsce package # → ackit-vscode-0.4.0.vsix
+vsce package # → ackit-vscode-0.5.0-dev.0.vsix
 ```
 
 Features: readiness tree, Problems `ACKITxxx`, graph “instructions for current file”, tasks/policy/optimize, palette `Refresh/Show Graph/Optimize/Diagnostics`, file watcher debounced, no telemetry.
@@ -371,7 +371,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the docs-first workflow.
 
 ### 🔖 Versioning
 
-Current: **`0.4.0`** on `master` · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases) · `latest → 0.4.0` via OIDC Trusted Publishing with provenance. Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
+Development: **`0.5.0-dev.0`** on `master` · Latest stable: **`0.4.1`** · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases/latest) · `latest → 0.4.1` via OIDC Trusted Publishing with provenance. Stable pointer: [`release-state.json`](release-state.json). Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
 
 ---
 

--- a/docs/decisions/ADR-0029-maintenance-aware-release-state-model.md
+++ b/docs/decisions/ADR-0029-maintenance-aware-release-state-model.md
@@ -1,0 +1,139 @@
+# ADR-0029: Maintenance-Aware Release-State Model
+
+Status: Accepted · Date: 2026-09-05 · Task: TASK-0078 (amends ADR-0023, which remains in force)
+
+## Context
+
+ADR-0023 defines one logical release (npm + VSIX + Action pin) with
+`package.json` as the single source-of-truth version and the release tag
+pointing at the commit whose `package.json` matches. That model assumes
+`package.json version == current public stable`. The v0.4.1 maintenance
+release — published from the separate `maintenance/v0.4.1` line while
+master stayed at source `0.4.0` — broke the assumption: default-branch
+README badges/pins still said `0.4.0` while npm/GitHub latest was `0.4.1`,
+and `scripts/check-version-parity.mjs` still PASSED because it compared
+stable surfaces against `package.json` only (false negative, reproduced
+in TASK-0078). The audit (recorded in TASK-0078) proved all package,
+TypeScript smoke, and VS Code CI tooling safely accept a `0.5.0-dev.0`
+source version, and that `release.yml` is fail-closed for prerelease tags.
+
+## Decision
+
+Four version concepts, each with exactly one owner (offline,
+deterministic, repository-native — no registry/network lookup in any
+product path):
+
+1. **Source/development version — owner: `package.json`.**
+   The v0.5 line on master is `0.5.0-dev.0` (explicit prerelease, NOT a
+   public release). `extensions/vscode/package.json` MUST equal it
+   (ADR-0023 coupling, unchanged) and the `ci.yml` extension job tracks
+   it (manifest contract + `ackit-vscode-<source>.vsix` filename).
+   `--version`, MCP `serverInfo.version`, and the SARIF driver version
+   report it dynamically. Bumping it changes no published artifact.
+
+2. **Published stable version — owner: `release-state.json`
+   (`publishedStable`, exact `X.Y.Z`, never a prerelease).**
+   Currently `0.4.1`. Every current-facing surface that makes a
+   PUBLIC/STABLE claim MUST name it: README install pins (`ackit
+   --version # <stable>`, `npx …@<stable>`), the Action pin
+   (`uses: …@v<stable>`), the getting-started one-shot pin, the VS Code
+   README Marketplace version claim, and the demo-Action pins. README
+   badges are version-agnostic instead of hard-coded (shields `npm/v/`
+   renders the registry latest dynamically; the release badge follows
+   `/releases/latest`), so they can never go stale again; the parity
+   guard checks their static URL text, keeping docs parity deterministic.
+
+3. **Maintenance-line semantics — owner: `release-state.json`
+   (`maintenanceSeries`, e.g. `["0.4.x"]`).**
+   A listed series exists as a long-lived branch (`maintenance/v0.4.1`)
+   and MAY publish `0.4.x` patches while master develops the next minor.
+   Maintenance releases never touch master versions, never move tags, and
+   never change the source line. Adding a series is a deliberate ADR-level
+   change, not an automatic one.
+
+4. **Historical-version semantics — owner: history itself, allowlisted.**
+   CHANGELOG history, `docs/v0.2.0/**`, old ADRs/tasks/evidence, API
+   "since" notes, behavioral baseline pins, release-debut notes
+   ("released in 0.4.0"), protocol generations, schema versions, and
+   SARIF 2.1.0 remain valid forever. The guard allowlists exact phrases
+   and never scans historical paths — no broad regex purge.
+
+**Release-tag / version relationship (unchanged, hardened by tests):**
+tags stay exact `vX.Y.Z` stable only. The `v*.*.*` trigger glob matches a
+prerelease-shaped tag such as `v0.5.0-dev.0`, but the release.yml step-1
+validator (`^v[0-9]+\.[0-9]+\.[0-9]+$`) rejects it before install, tests,
+or publish — fail-closed. `tests/contract/ci-pinning.test.ts` (which
+already rejects `v0.1.1-beta`) plus the new `isStableReleaseTag` parity
+tests pin this; no workflow change was needed and none is made.
+
+**When the stable pointer changes:** only in the task that performs (or
+immediately follows, with evidence) a successful publication — tag push →
+npm OIDC publish → registry/shasum/dist-tag verify → GitHub Release.
+The pointer commit sets `publishedStable` to the released version and
+updates the stable-claim surfaces in the same change. Master pushes and
+PRs never change it.
+
+**When `package.json` changes from dev prerelease to final:** in release
+preparation, the release task sets source `0.5.0-dev.0` → `0.5.0`
+(coupled extension manifest + CI job in the same change) before the
+exact-head green gate and tag. After publication, master immediately
+moves to the next line (`0.6.0-dev.0`).
+
+**Post-publish synchronization:** the release task verifies npm
+`dist-tags.latest`, the GitHub Release, and Marketplace propagation, then
+lands the pointer/surface sync above. Until that sync lands, the guard
+fails loudly (stale stable claims) rather than passing silently.
+
+**Future cases (solved without conflating the lines):**
+
+- `v0.5.0` public + `v0.6` development: release sets source `0.5.0`,
+  publishes, pointer `0.4.1 → 0.5.0`; master then opens `0.6.0-dev.0`.
+- `v0.5.1` maintenance while master is `v0.6-dev`: published from the
+  `0.5.x` maintenance line; only the pointer (`0.5.0 → 0.5.1`) and stable
+  surfaces move on master — source stays `0.6.0-dev.0`.
+- Emergency `v0.4.2` while master is `v0.5-dev`: published from
+  `maintenance/v0.4.1`; pointer `0.4.1 → 0.4.2` only (source untouched);
+  `maintenanceSeries` still covers it (`0.4.x`).
+
+## Rationale
+
+A split model (not another single-version assumption) is the smallest
+change that makes `README says 0.4.0 while npm latest is 0.4.1`
+mechanically impossible: source coupling and stable pins are checked
+against different committed truths. A prerelease source version was
+chosen over a stable-pointer-only alternative because every audited
+consumer (npm pack, `package-smoke.mjs`, TypeScript smoke, `vsce
+package` in CI, release.yml) accepts it, and it makes the development
+line self-describing (`--version` can never be mistaken for stable).
+
+## Alternatives considered
+
+- **Stable-pointer file only, source stays `0.4.0`:** rejected — master
+  would keep reporting a shipped maintenance version as its own truth and
+  `--version` would stay ambiguous about which line is developing.
+- **Dynamic registry lookup for stable:** rejected — violates the
+  offline-first invariant (REQ-GOV-001/002); the committed pointer keeps
+  the guard deterministic and network-free.
+- **General release-train framework:** rejected as over-engineering;
+  four concepts + guard + pointer discipline cover the known future cases.
+- **Narrowing the `v*.*.*` trigger glob:** rejected — the existing exact
+  validator already fails closed and is contract-tested; glob changes add
+  risk to release governance for no safety gain.
+
+## Consequences
+
+- `release-state.json` is a new tracked governance file; its shape is
+  validated by the guard and contract tests (unknown fields rejected to
+  keep it intentionally tiny — no `sourceVersion` duplication).
+- `README.md`, `docs/guides/getting-started.md`,
+  `extensions/vscode/README.md`, `docs/guides/agent-integration.md`
+  (published-npm clause), and `examples/demo-github-action/README.md`
+  now track stable `0.4.1`; `ci.yml` tracks source `0.5.0-dev.0`.
+- `tests/contract/ci-pinning.test.ts` is untouched (already fail-closed).
+- No tag, publish, release, or Marketplace action occurs in TASK-0078.
+
+## References
+
+- ADR-0023 (amended, still in force) · `release-state.json`
+- `scripts/check-version-parity.mjs` · `tests/contract/version-parity.test.ts`
+- `.github/workflows/release.yml` (step-1 validator) · TASK-0078 audit notes

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -38,3 +38,7 @@ TASK-0044 … TASK-0062):
 - ADR-0026 evidence contract v2 + independent verification protocol + verdicts
 - ADR-0027 checkpoints, resumability, local workflow store, task-aware packs
 - ADR-0028 policy v2 autonomy tiers + review policy + declarative gates + roles + skills projections
+
+v0.5 line additions (Accepted 2026-09-05, governing TASK-0078 … TASK-0086):
+
+- ADR-0029 maintenance-aware release-state model (amends ADR-0023: source/dev vs published-stable vs maintenance vs historical)

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -19,7 +19,7 @@ duplicates.
 ## Managed-asset lifecycle (init → sync)
 
 > Availability: `ackit sync` is RELEASED in `0.4.0` and ships in published npm
-> `@cynrath/agent-context-kit@0.4.0`.
+> `@cynrath/agent-context-kit@0.4.1`.
 
 `ackit init` is the first-time onboarding; `ackit sync` is the later,
 version-aware reconciliation. Both run on the same ownership engine — the

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,17 +14,17 @@ npm install --global @cynrath/agent-context-kit
 ackit --version
 ```
 
-One-shot usage: `npx --yes @cynrath/agent-context-kit@0.4.0 --help` (pinned to current `0.4.0`).
+One-shot usage: `npx --yes @cynrath/agent-context-kit@0.4.1 --help` (pinned to stable `0.4.1`).
 
 From a source checkout instead:
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
-node dist/cli/index.js --version  # 0.4.0
+node dist/cli/index.js --version  # 0.5.0-dev.0
 ```
 
-## 30-second tour (verified commands — v0.4.0)
+## 30-second tour (verified commands — stable v0.4.1)
 
 ```bash
 ackit init --dry-run          # plan instruction shims + builtin skills

--- a/docs/tasks/active/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
+++ b/docs/tasks/active/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
@@ -13,7 +13,7 @@ completedAt: null
 
 Fix the maintenance-line governance gap left by the v0.4.1 out-of-band maintenance release: current master still reports source version `0.4.0` in `package.json` and hard-codes `0.4.0` release truth in README badges while the latest published stable is `0.4.1`, and `scripts/check-version-parity.mjs` treats `package.json` as the single truth so it PASSES despite the stale default-branch README. Design and land a maintenance-aware release-state model that distinguishes source-checkout/development version, published stable version, historical versions, and maintenance-line versions, and teach the parity guard to understand them as separate concepts. No v0.5.0 publication occurs in this task.
 
-## Current-state evidence (verified live 2026-09-04 on master 725ed18)
+## Current-state evidence (implementation started 2026-09-04 from master f1550e4ca254f1df639a00f25cf121bd9c65e6fa; earlier observation on master 725ed18 retained below as historical evidence)
 
 - `package.json` version `0.4.0`; `extensions/vscode/package.json` version `0.4.0` (ADR-0023 coupling holds).
 - `npm view @cynrath/agent-context-kit version` → `0.4.1` (latest published stable).
@@ -58,7 +58,7 @@ Fix the maintenance-line governance gap left by the v0.4.1 out-of-band maintenan
 - [ ] Four version concepts defined, recorded, and asserted in distinct places; no concept conflated.
 - [ ] `README says 0.4.0 while npm latest is 0.4.1` class of staleness is impossible or mechanically detected (proven by positive + negative probes).
 - [ ] Parity guard green on the new model; historical references still pass; contract tests cover each concept.
-- [ ] No tag, publish, release, or version-bump side effects (`git tag --list`, `npm view` unchanged except by design docs).
+- [ ] No PUBLIC/STABLE release bump or publication side effects (`git tag --list`, `npm view`, GitHub Release, Marketplace remain 0.4.1). A source/development-version transition (e.g. to `0.5.0-dev.0`) is allowed only if selected by the ADR; it is NOT a public/stable release.
 - [ ] Decision recorded as ADR addendum/new ADR; task completed through the real gate with evidence.
 
 ## Test steps

--- a/docs/tasks/active/TASK-0083-provider-surface-and-integration-parity-audit-an.md
+++ b/docs/tasks/active/TASK-0083-provider-surface-and-integration-parity-audit-an.md
@@ -5,6 +5,7 @@ status: pending
 schemaVersion: 2
 dependencies:
   - "TASK-0078"
+  - "TASK-0081"
 createdAt: "2026-09-04"
 completedAt: null
 ---
@@ -35,6 +36,7 @@ Strong multi-auditor consensus (SHOULD, two linked items): provider-surface pari
 ## Dependencies
 
 - TASK-0078 (baseline vocabulary; capability table references stable concepts).
+- TASK-0081 (canonical workflow/evidence/verdict/status snapshot this task must expose/audit; scheduling before the status model exists is prohibited).
 
 ## Affected files / expected areas
 

--- a/docs/tasks/archive/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
+++ b/docs/tasks/archive/TASK-0078-v0-5-baseline-and-maintenance-aware-release-stat.md
@@ -1,12 +1,12 @@
 ---
 id: "TASK-0078"
 title: "v0.5 baseline and maintenance-aware release-state model"
-status: pending
+status: completed
 schemaVersion: 2
 dependencies:
   []
 createdAt: "2026-09-04"
-completedAt: null
+completedAt: 2026-09-05
 ---
 
 ## Purpose
@@ -54,12 +54,12 @@ Fix the maintenance-line governance gap left by the v0.4.1 out-of-band maintenan
 
 ## Acceptance criteria
 
-- [ ] Release-policy audit recorded (ADR-0023, parity script, release workflow, current-facing surfaces, npm latest) with live evidence.
-- [ ] Four version concepts defined, recorded, and asserted in distinct places; no concept conflated.
-- [ ] `README says 0.4.0 while npm latest is 0.4.1` class of staleness is impossible or mechanically detected (proven by positive + negative probes).
-- [ ] Parity guard green on the new model; historical references still pass; contract tests cover each concept.
-- [ ] No PUBLIC/STABLE release bump or publication side effects (`git tag --list`, `npm view`, GitHub Release, Marketplace remain 0.4.1). A source/development-version transition (e.g. to `0.5.0-dev.0`) is allowed only if selected by the ADR; it is NOT a public/stable release.
-- [ ] Decision recorded as ADR addendum/new ADR; task completed through the real gate with evidence.
+- [x] Release-policy audit recorded (ADR-0023, parity script, release workflow, current-facing surfaces, npm latest) with live evidence.
+- [x] Four version concepts defined, recorded, and asserted in distinct places; no concept conflated.
+- [x] `README says 0.4.0 while npm latest is 0.4.1` class of staleness is impossible or mechanically detected (proven by positive + negative probes).
+- [x] Parity guard green on the new model; historical references still pass; contract tests cover each concept.
+- [x] No PUBLIC/STABLE release bump or publication side effects (`git tag --list`, `npm view`, GitHub Release, Marketplace remain 0.4.1). A source/development-version transition (e.g. to `0.5.0-dev.0`) is allowed only if selected by the ADR; it is NOT a public/stable release.
+- [x] Decision recorded as ADR addendum/new ADR; task completed through the real gate with evidence.
 
 ## Test steps
 
@@ -83,6 +83,28 @@ Fix the maintenance-line governance gap left by the v0.4.1 out-of-band maintenan
 
 - Focused revert of the model/guard commit(s) on the task branch before merge; after merge, a forward fix (never history rewrite).
 
+## Audit (recorded 2026-09-05 on feat/task-0078-release-state; live evidence)
+
+- ADR-0023 (`docs/decisions/ADR-0023-*`): one logical release, `package.json` source-of-truth, tag == package version, tags-only `v*.*.*` OIDC publish; no maintenance-line concept (gap).
+- Parity guard (`scripts/check-version-parity.mjs`): `package.json` single truth; `MUST_SHOW_CURRENT` forces stable surfaces to name the source version verbatim; `findStaleRefs` only flags older-than-source. Live: `node scripts/check-version-parity.mjs` → PASS on `0.4.0` while npm/GitHub latest is `0.4.1` (false negative, reproduced).
+- `release.yml`: trigger tags-only `v*.*.*` (ll.25-28); step-1 validator `^v[0-9]+\.[0-9]+\.[0-9]+$` + tag==package.json + name check (ll.57-90). Master push/PR can never publish.
+- `ci.yml` extension job hard-codes source `0.4.0` (manifest contract, `vsce package --out ackit-vscode-0.4.0.vsix`, file checks).
+- Source surfaces: `package.json`, `extensions/vscode/package.json`, source-checkout `--version`, MCP `serverInfo.version`, SARIF driver version (dynamic), VSIX filename, `ci.yml` extension job. Stable surfaces: README badges/install/Action pins/Versioning, getting-started one-shot pin, VS Code README Version/Marketplace claim, `examples/demo-github-action` pins.
+- Q1 npm + `0.5.0-dev.0`: SAFE. Temp-dir `npm pack --dry-run` with `0.5.0-dev.0` → `probe-pkg-0.5.0-dev.0.tgz` OK. `scripts/package-smoke.mjs` ll.82-84 compares dynamically; `tests/contract/version-single-source.test.ts:29` allows prerelease; `prepack` version-agnostic.
+- Q2 TS/smoke: SAFE. `src/shared/version.ts` dynamic; `tests/e2e/cli-scaffold.smoke.mjs:30,38` dynamic/prefix match.
+- Q3 VS Code: SAFE for CI scope. CI runs only `vsce ls` + `vsce package` (never `publish`); `0.5.0-dev.0` is semver-valid; version flows to `--out` filename. Empirical `vsce package` proof runs post-bump in validation.
+- Q4 master prerelease publish: IMPOSSIBLE (tags-only trigger; version string irrelevant).
+- Q5 tag `v0.5.0-dev.0`: trigger glob MATCHES (third `*` eats `0-dev.0`) but step-1 validator REJECTS (exit 1) before install/publish — fail-closed, no silent stable publish. No workflow change needed; validator pinned by contract test.
+- Q6: see source/stable surface lists above.
+- Q7 badges dynamic: YES. Shields `npm/v/` renders registry latest without a hard-coded label; `github/v/release` + `/releases/latest` destination version-agnostic; pinned installs stay explicit but track the stable pointer. Guard checks static text → determinism preserved.
+- Decision: adopt split model — source `0.5.0-dev.0` (both manifests), stable pointer `release-state.json` (`publishedStable 0.4.1`, `maintenanceSeries ["0.4.x"]`), history untouched. Full rationale in ADR-0029.
+
 ## Completion notes
 
-(placeholder)
+Implemented 2026-09-05 on `feat/task-0078-release-state` (plan-fix commit `e1810ee` first, then this implementation).
+
+Model landed (ADR-0029): source `0.5.0-dev.0` (`package.json` + `extensions/vscode/package.json`, coupled); stable `0.4.1` (`release-state.json`); maintenance `["0.4.x"]`; history allowlisted. README badges version-agnostic (`npm/v/` dynamic, `github/v/release` + `/releases/latest`); install/Action/Marketplace pins track stable `0.4.1`; `ci.yml` extension job tracks source.
+
+Evidence: `node scripts/check-version-parity.mjs` → PASS (source 0.5.0-dev.0, stable 0.4.1, 14 files); negative probes A-E in `tests/contract/version-parity.test.ts` (26 tests) + `readme-current` (11) + `readme-parity` (4, incl. real `npm pack` tarball README equality) + `version-single-source` (3) + `ci-pinning` (19, prerelease-tag rejection pinned) all green; full `pnpm test` 103 files / 612 tests green (serial clean run; two earlier parallel runs hit git-fixture timeout flakes that pass isolated and serially). Gates: lint, format:check, typecheck, build, gen:schemas idempotent, smoke:cli, smoke:package (`cynrath-agent-context-kit-0.5.0-dev.0.tgz`, nothing published), `vsce package` → `ackit-vscode-0.5.0-dev.0.vsix` 653263 bytes <2MB file-list clean (artifact removed), offline-egress PASS, text-hygiene clean, doctor/task-doctor/skills-validate/scan--ci (readiness 88) PASS, `git diff --check` clean.
+
+No-publication proof: `git tag --list v0.5*` empty; `npm view` → `0.4.1`; `gh release list` latest `v0.4.1`; no Marketplace publish; `maintenance/v0.4.1` and `feat/browser-companion-v0.3` untouched; TASK-0079..0086 not started. Fresh-verifier + squash-merge gate happens on the PR.

--- a/examples/demo-github-action/README.md
+++ b/examples/demo-github-action/README.md
@@ -1,6 +1,6 @@
 # Demo: GitHub Action
 
-Official `Cynrath/agent-context-kit@v0.4.0`
+Official `Cynrath/agent-context-kit@v0.4.1`
 
 ```yaml
 permissions:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
-      - uses: Cynrath/agent-context-kit@v0.4.0
+      - uses: Cynrath/agent-context-kit@v0.4.1
         with:
           command: scan
           args: "--json"

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -3,7 +3,7 @@
 Offline-first agent readiness for your repository — directly inside VS Code.
 
 - **Publisher:** `Cynrath` (`Cynrath.ackit-vscode`)
-- **Version:** `0.4.0`
+- **Version:** `0.4.1` (Marketplace stable; source checkouts build `0.5.0-dev.0`)
 - **Engine:** `VS Code ^1.90.0`
 - **Activation:** `onStartupFinished` (debounced, lazy refresh)
 - **Category:** `Linters`
@@ -70,7 +70,7 @@ All commands support multi-root: `getRootForActiveEditor()` → active editor's 
 - Docs: https://cynrath.github.io/agent-context-kit/
 - Guides: https://cynrath.github.io/agent-context-kit/vscode/
 - Marketplace: https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode
-- Changelog: `CHANGELOG.md` (v0.4.0)
+- Changelog: `CHANGELOG.md` (see CHANGELOG for the version history)
 
 ## Screenshots
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ackit-vscode",
   "displayName": "ACKit Toolkit",
   "description": "Offline-first agent readiness toolkit for VS Code",
-  "version": "0.4.0",
+  "version": "0.5.0-dev.0",
   "publisher": "Cynrath",
   "engines": {
     "vscode": "^1.90.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cynrath/agent-context-kit",
-  "version": "0.4.0",
+  "version": "0.5.0-dev.0",
   "description": "ACKit turns any repository into an agent-ready repository: instruction graph, agent skills, security scanning, context budgeting, task-first workflow, policy-as-code, and MCP integration. Offline-first and deterministic.",
   "keywords": [
     "ackit",

--- a/release-state.json
+++ b/release-state.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "publishedStable": "0.4.1",
+  "maintenanceSeries": ["0.4.x"]
+}

--- a/scripts/check-version-parity.d.mts
+++ b/scripts/check-version-parity.d.mts
@@ -3,8 +3,16 @@ export interface StaleRef {
   text: string;
 }
 
+export interface ReleaseState {
+  schemaVersion: 1;
+  publishedStable: string;
+  maintenanceSeries: string[];
+}
+
 export declare const CURRENT_FILES: string[];
+export declare const MUST_SHOW_STABLE: string[];
 export declare const MUST_SHOW_CURRENT: string[];
+export declare const SOURCE_TRACKING_FILES: string[];
 export declare const STRIP_ALLOWLIST: string[];
 
 export declare function parseVersion(version: string): {
@@ -12,7 +20,22 @@ export declare function parseVersion(version: string): {
   minor: number;
   patch: number;
 };
+export declare function isPrereleaseVersion(version: string): boolean;
+export declare function isStableReleaseTag(tag: string): boolean;
 export declare function stripAllowed(content: string): string;
-export declare function findStaleRefs(content: string, current: string): StaleRef[];
+export declare function findStaleRefs(content: string, baseline: string): StaleRef[];
+export declare function validateReleaseState(state: unknown): string[];
+export declare function readReleaseState(): ReleaseState;
+export declare function readSourceVersion(): string;
 export declare function readCurrentVersion(): string;
-export declare function checkParity(): { current: string; failures: string[] };
+export declare function readPublishedStable(): string;
+export declare function checkParity(overrides?: {
+  sourceVersion?: string;
+  releaseState?: unknown;
+  files?: Record<string, string>;
+}): {
+  source: string | undefined;
+  stable: string | undefined;
+  current: string | undefined;
+  failures: string[];
+};

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -1,18 +1,27 @@
 #!/usr/bin/env node
 /**
- * Current-vs-historical version parity guard (TASK-0073).
+ * Maintenance-aware release-state parity guard (TASK-0078, ADR-0029).
  *
- * Rule: historical version references are legitimate and must be preserved
- * (CHANGELOG history, docs/v0.2.0/**, old ADRs, task records, behavioral
- * baseline pins, API "since" notes, protocol/generation markers). Old
- * versions must NOT remain as current truth in current-facing surfaces.
+ * Four version concepts, asserted in distinct places (never conflated):
  *
- * - `package.json` is the single source of truth for the current version.
- * - `extensions/vscode/package.json` must equal it (ADR-0023 coupling).
- * - CURRENT_FILES must show the current version where they state release
- *   truth and must not claim an older 0.x line as current.
- * - The guard never scans historical paths, lockfiles, or generated output,
- *   so legitimate history can never fail it.
+ * 1. source/development — `package.json` owns it (e.g. `0.5.0-dev.0` on the
+ *    v0.5 line). `extensions/vscode/package.json` must equal it (ADR-0023
+ *    coupling) and the `.github/workflows/ci.yml` extension job tracks it
+ *    (manifest contract + VSIX filename). This is NOT a public release.
+ * 2. published stable — `release-state.json` `publishedStable` owns it
+ *    (e.g. `0.4.1`). Current-facing surfaces that make PUBLIC/STABLE claims
+ *    (README install pins, release labels/links, getting-started one-shot
+ *    pins, VS Code README Marketplace claims) must name it.
+ * 3. maintenance — `release-state.json` `maintenanceSeries` (e.g. `0.4.x`):
+ *    the long-lived maintenance line(s) that may publish patches while
+ *    master develops the next minor. Informational + well-formedness checked.
+ * 4. historical — CHANGELOG history, docs/v0.2.0/**, old ADRs, task records,
+ *    behavioral baseline pins, API "since" notes, protocol/generation
+ *    markers, SARIF 2.1.0. Allowlisted and never scanned, so legitimate
+ *    history can never fail the guard.
+ *
+ * Offline, deterministic, repository-native: no registry/network lookup.
+ * The published-stable pointer is a committed file, never a live query.
  *
  * Exit 0 when parity holds, 1 with a file:line report otherwise.
  */
@@ -43,13 +52,28 @@ export const CURRENT_FILES = [
 ];
 
 /**
- * Files in this set state the current release outright, so they must name
- * the current version somewhere (badges, install pins, metadata).
+ * Files in this set make PUBLIC/STABLE claims outright, so they must name
+ * the published stable version somewhere (install pins, release labels).
+ * They MUST NOT be forced to name the source/development version.
  */
-export const MUST_SHOW_CURRENT = [
+export const MUST_SHOW_STABLE = [
   "README.md",
   "docs/guides/getting-started.md",
   "extensions/vscode/README.md",
+];
+
+/** Legacy alias (pre-TASK-0078 name for the same file set, now stable-scoped). */
+export const MUST_SHOW_CURRENT = MUST_SHOW_STABLE;
+
+/**
+ * Files that track the SOURCE version (never the stable pointer): the two
+ * manifests (equality-coupled) and the CI extension job (contract + VSIX).
+ * Everything else in CURRENT_FILES is stale-checked against stable.
+ */
+export const SOURCE_TRACKING_FILES = [
+  "package.json",
+  "extensions/vscode/package.json",
+  ".github/workflows/ci.yml",
 ];
 
 /**
@@ -63,6 +87,8 @@ export const MUST_SHOW_CURRENT = [
  * - API "since" notes (which release added the export)
  * - historical directory labels (which release a history directory belongs
  *   to — e.g. the docs-table link label and the AGENTS.md entry-point label)
+ * - release-debut notes ("released in 0.4.0" = which release introduced the
+ *   capability, still true after later releases; NOT a stable claim)
  */
 export const STRIP_ALLOWLIST = [
   // Exact historical phrases first (they contain docs/v0.2.0, so they must
@@ -76,9 +102,15 @@ export const STRIP_ALLOWLIST = [
   "keeps v0.2.2 behavior",
   "exported since v0.2.0",
   "readiness (v0.2.0)",
+  "is RELEASED in `0.4.0`",
+  "released in 0.4.0",
 ];
 
 const VERSION_RE = /\bv?(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?\b/g;
+const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+const MAINTENANCE_SERIES_RE = /^\d+\.\d+\.x$/;
+/** Stable release tags: exact vX.Y.Z, never a prerelease (mirrors release.yml). */
+const STABLE_TAG_RE = /^v\d+\.\d+\.\d+$/;
 
 export function parseVersion(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(version);
@@ -90,6 +122,21 @@ export function parseVersion(version) {
   };
 }
 
+/** True for development prereleases such as `0.5.0-dev.0` (never stable). */
+export function isPrereleaseVersion(version) {
+  return String(version).includes("-");
+}
+
+/**
+ * True only for exact stable release tags (`v0.4.1`). Prerelease-shaped
+ * tags (`v0.5.0-dev.0`), bare versions, and partial versions are rejected —
+ * the same fail-closed rule as the release.yml step-1 validator, so a
+ * prerelease tag can never silently become a normal stable release.
+ */
+export function isStableReleaseTag(tag) {
+  return STABLE_TAG_RE.test(String(tag));
+}
+
 export function stripAllowed(content) {
   let out = content;
   for (const needle of STRIP_ALLOWLIST) out = out.split(needle).join("");
@@ -98,13 +145,14 @@ export function stripAllowed(content) {
 
 /**
  * Return stale current-facing version references as { line, text } rows.
- * A reference is stale when it names the 0.x line older than `current`
- * (older minor, or older patch on the same minor). Other majors, protocol
- * generations (v2), schema versions, and SARIF 2.1.0 never match the 0.x
- * rule and are always kept.
+ * A reference is stale when it names the 0.x line older than `baseline`
+ * (older minor, or older patch on the same minor). Newer references
+ * (e.g. a `0.5.0-dev.0` source string scanned against the `0.4.1` stable
+ * baseline) are never stale. Other majors, protocol generations (v2),
+ * schema versions, and SARIF 2.1.0 never match the 0.x rule and are kept.
  */
-export function findStaleRefs(content, current) {
-  const { minor, patch } = parseVersion(current);
+export function findStaleRefs(content, baseline) {
+  const { minor, patch } = parseVersion(baseline);
   const rows = [];
   const lines = stripAllowed(content).split("\n");
   for (let index = 0; index < lines.length; index++) {
@@ -123,60 +171,182 @@ export function findStaleRefs(content, current) {
   return rows;
 }
 
-export function readCurrentVersion() {
+/**
+ * Validate a parsed release-state.json value. Returns error strings
+ * (empty when valid). The file stays intentionally tiny: exactly the
+ * three known fields, a stable (never prerelease) pointer, and
+ * well-formed maintenance series entries.
+ */
+export function validateReleaseState(state) {
+  if (state === null || typeof state !== "object" || Array.isArray(state)) {
+    return ["release-state.json must be a JSON object"];
+  }
+  const errors = [];
+  if (state.schemaVersion !== 1) {
+    errors.push("release-state.json schemaVersion must be 1");
+  }
+  if (typeof state.publishedStable !== "string" || !STABLE_VERSION_RE.test(state.publishedStable)) {
+    errors.push(
+      "release-state.json publishedStable must be an exact X.Y.Z stable version (never a prerelease)",
+    );
+  }
+  if (
+    !Array.isArray(state.maintenanceSeries) ||
+    state.maintenanceSeries.length === 0 ||
+    !state.maintenanceSeries.every(
+      (entry) => typeof entry === "string" && MAINTENANCE_SERIES_RE.test(entry),
+    )
+  ) {
+    errors.push('release-state.json maintenanceSeries must be a non-empty array like ["0.4.x"]');
+  }
+  const known = new Set(["schemaVersion", "publishedStable", "maintenanceSeries"]);
+  const unknown = Object.keys(state).filter((key) => !known.has(key));
+  if (unknown.length > 0) {
+    errors.push(`release-state.json has unknown field(s): ${unknown.join(", ")}`);
+  }
+  return errors;
+}
+
+export function readReleaseState() {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path.join(repoRoot, "release-state.json"), "utf8"));
+  } catch {
+    throw new Error("release-state.json is missing or not valid JSON");
+  }
+  const errors = validateReleaseState(parsed);
+  if (errors.length > 0) throw new Error(`invalid release-state.json: ${errors.join("; ")}`);
+  return parsed;
+}
+
+/** Source/development version owner: package.json (e.g. `0.5.0-dev.0`). */
+export function readSourceVersion() {
   const pkg = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   if (typeof pkg.version !== "string") throw new Error("package.json has no version");
   return pkg.version;
+}
+
+/** Legacy alias (pre-TASK-0078 single-truth name). Prefer readSourceVersion(). */
+export function readCurrentVersion() {
+  return readSourceVersion();
+}
+
+/** Published stable version owner: release-state.json (e.g. `0.4.1`). */
+export function readPublishedStable() {
+  return readReleaseState().publishedStable;
 }
 
 function readRepo(relativePath) {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
-export function checkParity() {
+/**
+ * Run the guard. Optional overrides (for contract negative probes only):
+ * `{ sourceVersion, releaseState, files }` where `files` maps repo-relative
+ * paths to fixture content. Without overrides the working tree is checked.
+ */
+export function checkParity(overrides = {}) {
   const failures = [];
-  const current = readCurrentVersion();
+  const readFile =
+    overrides.files !== undefined
+      ? (relativePath) => {
+          if (!(relativePath in overrides.files)) {
+            throw new Error(`probe has no fixture for ${relativePath}`);
+          }
+          return overrides.files[relativePath];
+        }
+      : readRepo;
 
-  const extensionPkg = JSON.parse(readRepo("extensions/vscode/package.json"));
-  if (extensionPkg.version !== current) {
-    failures.push(
-      `extensions/vscode/package.json version '${extensionPkg.version}' != package.json '${current}' (ADR-0023 coupling)`,
-    );
+  let source;
+  try {
+    source = overrides.sourceVersion ?? readSourceVersion();
+    parseVersion(source);
+  } catch (error) {
+    failures.push(`source version unreadable: ${error.message}`);
   }
 
-  const ci = readRepo(".github/workflows/ci.yml");
-  if (!ci.includes(`'${current}'`)) {
-    failures.push(`.github/workflows/ci.yml manifest contract does not assert '${current}'`);
-  }
-  if (!ci.includes(`ackit-vscode-${current}.vsix`)) {
-    failures.push(`.github/workflows/ci.yml VSIX filename does not track '${current}'`);
+  let stable;
+  try {
+    const state = overrides.releaseState ?? readReleaseState();
+    const errors = validateReleaseState(state);
+    if (errors.length > 0) throw new Error(errors.join("; "));
+    stable = state.publishedStable;
+  } catch (error) {
+    failures.push(`published-stable pointer unreadable: ${error.message}`);
   }
 
-  for (const file of MUST_SHOW_CURRENT) {
-    if (!readRepo(file).includes(current)) {
-      failures.push(`${file} does not name current version ${current}`);
+  if (source !== undefined) {
+    let extensionVersion;
+    try {
+      extensionVersion = JSON.parse(readFile("extensions/vscode/package.json")).version;
+    } catch (error) {
+      failures.push(`extension manifest unreadable: ${error.message}`);
+    }
+    if (extensionVersion !== undefined && extensionVersion !== source) {
+      failures.push(
+        `extensions/vscode/package.json version '${extensionVersion}' != package.json '${source}' (ADR-0023 coupling)`,
+      );
+    }
+
+    let ci = "";
+    try {
+      ci = readFile(".github/workflows/ci.yml");
+    } catch (error) {
+      failures.push(`ci workflow unreadable: ${error.message}`);
+    }
+    if (ci !== "") {
+      if (!ci.includes(`'${source}'`)) {
+        failures.push(`.github/workflows/ci.yml manifest contract does not assert '${source}'`);
+      }
+      if (!ci.includes(`ackit-vscode-${source}.vsix`)) {
+        failures.push(`.github/workflows/ci.yml VSIX filename does not track '${source}'`);
+      }
     }
   }
 
-  for (const file of CURRENT_FILES) {
-    const stale = findStaleRefs(readRepo(file), current);
-    for (const row of stale) {
-      failures.push(`${file}:${row.line} stale current-facing reference '${row.text}'`);
+  if (stable !== undefined) {
+    for (const file of MUST_SHOW_STABLE) {
+      let content = "";
+      try {
+        content = readFile(file);
+      } catch (error) {
+        failures.push(`${file} unreadable: ${error.message}`);
+        continue;
+      }
+      if (!content.includes(stable)) {
+        failures.push(`${file} does not name published stable ${stable}`);
+      }
     }
   }
 
-  return { current, failures };
+  if (source !== undefined && stable !== undefined) {
+    for (const file of CURRENT_FILES) {
+      let content = "";
+      try {
+        content = readFile(file);
+      } catch {
+        continue;
+      }
+      const baseline = SOURCE_TRACKING_FILES.includes(file) ? source : stable;
+      const stale = findStaleRefs(content, baseline);
+      for (const row of stale) {
+        failures.push(`${file}:${row.line} stale current-facing reference '${row.text}'`);
+      }
+    }
+  }
+
+  return { source, stable, current: source, failures };
 }
 
 function main() {
-  const { current, failures } = checkParity();
+  const { source, stable, failures } = checkParity();
   if (failures.length > 0) {
-    console.error(`[version-parity] FAIL — current version ${current}, stale refs found:`);
+    console.error(`[version-parity] FAIL — source ${source}, stable ${stable}:`);
     for (const failure of failures) console.error(`  ${failure}`);
     process.exit(1);
   }
   console.log(
-    `[version-parity] PASS — current ${current}; ${CURRENT_FILES.length} current-facing files clean, extension coupled`,
+    `[version-parity] PASS — source ${source}, stable ${stable}; ${CURRENT_FILES.length} current-facing files clean, extension coupled`,
   );
 }
 

--- a/tests/contract/readme-current.test.ts
+++ b/tests/contract/readme-current.test.ts
@@ -2,9 +2,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-// Post-release closure, release-proof: current public entry points must state
-// current release truth (never a stale line), without hard-coding any version
-// here. Exact stale-vs-historical classification lives in
+// Post-release closure, release-proof: stable public entry points must state
+// the PUBLISHED STABLE truth (never a stale line), without hard-coding any
+// version here. The source/development version is intentionally NOT required
+// in these files (TASK-0078 split model). Exact stale-vs-historical
+// classification lives in
 // scripts/check-version-parity.mjs + tests/contract/version-parity.test.ts.
 const VERSIONED_CURRENT_FILES = ["README.md", "docs/guides/getting-started.md"];
 
@@ -14,14 +16,14 @@ function readRepo(file: string): string {
   return readFileSync(path.join(process.cwd(), file), "utf8");
 }
 
-function packageVersion(): string {
-  const pkg = JSON.parse(readRepo("package.json")) as { version: string };
-  return pkg.version;
+function publishedStable(): string {
+  const state = JSON.parse(readRepo("release-state.json")) as { publishedStable: string };
+  return state.publishedStable;
 }
 
 describe("current docs advertise the current release (post-release closure)", () => {
-  it.each(VERSIONED_CURRENT_FILES)("%s names the package version", (file) => {
-    expect(readRepo(file)).toContain(packageVersion());
+  it.each(VERSIONED_CURRENT_FILES)("%s names the published stable version", (file) => {
+    expect(readRepo(file)).toContain(publishedStable());
   });
 
   it.each(VERSION_AGNOSTIC_FILES)(
@@ -39,7 +41,7 @@ describe("current docs advertise the current release (post-release closure)", ()
         .join("")
         .split("v0.2.0 historical contract")
         .join("");
-      const [major = 0, minor = 0, patch = 0] = packageVersion().split(".").map(Number);
+      const [major = 0, minor = 0, patch = 0] = publishedStable().split(".").map(Number);
       const refs = stripped.match(/\bv?0\.(\d+)\.(\d+)\b/g) ?? [];
       for (const ref of refs) {
         const nums = ref.replace(/^v/, "").split(".").map(Number);

--- a/tests/contract/readme-parity.test.ts
+++ b/tests/contract/readme-parity.test.ts
@@ -19,30 +19,37 @@ describe("npm README parity", () => {
     expect(pkg.files).toContain("README.md");
   });
 
-  it("root README contains current-version badges and examples (not stale older lines)", async () => {
+  it("root README tracks stable pins with version-agnostic badges (split release-state model)", async () => {
     const readme = await fsp.readFile(path.join(repoRoot, "README.md"), "utf8");
     const pkg = JSON.parse(await fsp.readFile(path.join(repoRoot, "package.json"), "utf8")) as {
       version: string;
     };
-    const ver = pkg.version; // single source of truth, dynamic across releases
-    expect(ver).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(readme).toContain(`v${ver}`);
-    expect(readme).toContain(`npm%20v${ver}`);
-    expect(readme).toContain(`release-v${ver}`);
-    expect(readme).toContain(`npx --yes @cynrath/agent-context-kit@${ver}`);
-    expect(readme).toContain(`Cynrath/agent-context-kit@v${ver}`);
-    // Ensure old version not present in badge areas (allow docs/v0.2.0 folder reference)
-    // The only allowed old line there is in docs/v0.2.0 paths and legacy notes
+    const state = JSON.parse(
+      await fsp.readFile(path.join(repoRoot, "release-state.json"), "utf8"),
+    ) as { publishedStable: string };
+    const source = pkg.version; // source/development version (may be a prerelease)
+    const stable = state.publishedStable; // published stable (always exact X.Y.Z)
+    expect(source).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+    expect(stable).toMatch(/^\d+\.\d+\.\d+$/);
+    // Badges are version-agnostic: the npm badge renders the registry latest
+    // dynamically and the release badge follows /releases/latest — no
+    // hard-coded version may remain in badge labels/links.
+    expect(readme).toContain("npm/v/@cynrath/agent-context-kit?label=npm");
+    expect(readme).toContain("github/v/release/Cynrath/agent-context-kit");
+    expect(readme).toContain("github.com/Cynrath/agent-context-kit/releases/latest");
     const withoutDocs = readme.replaceAll("docs/v0.2.0", "");
-    // Check that npm badge not stale
-    expect(withoutDocs).not.toContain("npm%20v0.2.0");
-    expect(withoutDocs).not.toContain("release-v0.2.0");
-    // Ensure the previous minor's stale badges are gone (dynamic across releases)
-    const [badgeMajor = 0, badgeMinor = 0] = ver.split(".").map(Number);
-    if (badgeMinor > 0) {
-      const prevMinor = `${badgeMajor}.${badgeMinor - 1}`;
-      expect(withoutDocs).not.toContain(`npm%20v${prevMinor}`);
-      expect(withoutDocs).not.toContain(`release-v${prevMinor}`);
+    expect(withoutDocs).not.toContain("npm%20v0.");
+    expect(withoutDocs).not.toContain("release-v0.");
+    expect(withoutDocs).not.toContain("releases/tag/v0.");
+    // Pinned install/action references track the STABLE pointer, not source.
+    expect(readme).toContain(`npx --yes @cynrath/agent-context-kit@${stable}`);
+    expect(readme).toContain(`Cynrath/agent-context-kit@v${stable}`);
+    expect(readme).toContain(`ackit --version  # ${stable}`);
+    // The development version must never be presented as an installable
+    // stable reference when it is a prerelease.
+    if (source.includes("-")) {
+      expect(readme).not.toContain(`@cynrath/agent-context-kit@${source}`);
+      expect(readme).not.toContain(`agent-context-kit@v${source}`);
     }
   });
 

--- a/tests/contract/version-parity.test.ts
+++ b/tests/contract/version-parity.test.ts
@@ -2,35 +2,73 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { findStaleRefs, readCurrentVersion } from "../../scripts/check-version-parity.mjs";
+import {
+  CURRENT_FILES,
+  checkParity,
+  findStaleRefs,
+  isPrereleaseVersion,
+  isStableReleaseTag,
+  MUST_SHOW_STABLE,
+  readPublishedStable,
+  readReleaseState,
+  readSourceVersion,
+  validateReleaseState,
+} from "../../scripts/check-version-parity.mjs";
 
-// Deterministic classifier/guard tests (TASK-0073): the guard must catch
-// stale CURRENT-facing claims without failing on legitimate history.
-const CURRENT = "0.4.0";
+// Maintenance-aware release-state tests (TASK-0078, ADR-0029): the guard
+// distinguishes source/development, published stable, maintenance, and
+// historical version concepts. Classifier vectors use explicit baselines;
+// tree-coupled probes read the live files so they stay green across
+// releases (no hard-coded current version here).
+const STABLE_VECTOR = "0.4.1";
+const SOURCE_VECTOR = "0.5.0-dev.0";
 
-describe("version-parity classifier", () => {
-  it("flags a stale 0.2.0 current claim", () => {
-    const rows = findStaleRefs("ships as the scoped npm package `0.2.0`", CURRENT);
+function readTree(): Record<string, string> {
+  const files: Record<string, string> = {};
+  for (const file of CURRENT_FILES) {
+    files[file] = readFileSync(path.join(process.cwd(), file), "utf8");
+  }
+  return files;
+}
+
+describe("version-parity classifier (stable vs source baselines)", () => {
+  it("flags a stale 0.2.0 stable claim", () => {
+    const rows = findStaleRefs("ships as the scoped npm package `0.2.0`", STABLE_VECTOR);
     expect(rows.map((row) => row.text)).toEqual(["0.2.0"]);
   });
 
-  it("flags a stale 0.3.x claim once 0.4.0 is current", () => {
-    const rows = findStaleRefs("ackit --version  # 0.3.0", CURRENT);
-    expect(rows.map((row) => row.text)).toEqual(["0.3.0"]);
+  it("flags a stale 0.4.0 claim once 0.4.1 is stable (probe A shape)", () => {
+    const rows = findStaleRefs(
+      "npx --yes @cynrath/agent-context-kit@0.4.0 --version",
+      STABLE_VECTOR,
+    );
+    expect(rows.map((row) => row.text)).toEqual(["0.4.0"]);
   });
 
-  it("passes the current version itself", () => {
-    expect(findStaleRefs("Current: **`0.4.0`** on `master`", CURRENT)).toEqual([]);
+  it("passes the stable version itself", () => {
+    expect(findStaleRefs("Latest stable: **`0.4.1`** on npm", STABLE_VECTOR)).toEqual([]);
+  });
+
+  it("does not mistake the development prerelease for a stale stable ref", () => {
+    expect(findStaleRefs("source checkout builds 0.5.0-dev.0", STABLE_VECTOR)).toEqual([]);
+    expect(findStaleRefs("Development: 0.5.0-dev.0 on master", SOURCE_VECTOR)).toEqual([]);
+  });
+
+  it("documents why baselines differ: stable reads as older-than-source", () => {
+    // `0.4.1` IS older than the `0.5.0-dev.0` source line, so stable-scoped
+    // files must be checked against the stable baseline — never the source.
+    const rows = findStaleRefs("Latest stable: 0.4.1", SOURCE_VECTOR);
+    expect(rows.map((row) => row.text)).toEqual(["0.4.1"]);
   });
 
   it("keeps historical docs/v0.2.0 path references", () => {
     expect(
-      findStaleRefs("see `docs/v0.2.0/REQUIREMENTS.md` for the old contract", CURRENT),
+      findStaleRefs("see `docs/v0.2.0/REQUIREMENTS.md` for the old contract", STABLE_VECTOR),
     ).toEqual([]);
   });
 
   it("keeps the loopback address (not a version)", () => {
-    expect(findStaleRefs("dashboard on http://127.0.0.1:54321", CURRENT)).toEqual([]);
+    expect(findStaleRefs("dashboard on http://127.0.0.1:54321", STABLE_VECTOR)).toEqual([]);
   });
 
   it("keeps protocol/generation markers (not package versions)", () => {
@@ -42,31 +80,172 @@ describe("version-parity classifier", () => {
       "SARIF 2.1.0",
       "$schema: https://json.schemastore.org/sarif-2.1.0.json",
     ].join("\n");
-    expect(findStaleRefs(content, CURRENT)).toEqual([]);
+    expect(findStaleRefs(content, STABLE_VECTOR)).toEqual([]);
   });
 
   it("keeps the intentional historical-releases note", () => {
-    expect(findStaleRefs("`0.1.1`/`0.1.0` remain as historical releases", CURRENT)).toEqual([]);
+    expect(findStaleRefs("`0.1.1`/`0.1.0` remain as historical releases", STABLE_VECTOR)).toEqual(
+      [],
+    );
   });
 
-  it("keeps behavioral baseline pins and API since-notes", () => {
+  it("keeps behavioral baseline pins, API since-notes, and release-debut notes", () => {
     const content = [
       "Absent `workflow:` preserves exact v0.3.0 defaults (legacy repos unchanged).",
       "This keeps v0.2.2 behavior for repositories that never configured autonomy.",
       "Evaluates declarative rule packs (exported since v0.2.0).",
       "Merged config (scan + context + policy + readiness (v0.2.0) + profile).",
+      "`ackit sync` is RELEASED in `0.4.0` and later.",
+      "reconcile assets (released in 0.4.0)",
     ].join("\n");
-    expect(findStaleRefs(content, CURRENT)).toEqual([]);
+    expect(findStaleRefs(content, STABLE_VECTOR)).toEqual([]);
   });
 
   it("reports the exact line number of a stale hit", () => {
-    const rows = findStaleRefs("clean line\nstale 0.3.0 here\n", CURRENT);
+    const rows = findStaleRefs("clean line\nstale 0.3.0 here\n", STABLE_VECTOR);
     expect(rows).toEqual([{ line: 2, text: "0.3.0" }]);
   });
+});
 
-  it("reads package.json as the single source of truth", () => {
+describe("release-state pointer (published stable + maintenance)", () => {
+  it("release-state.json is valid and owns the stable pointer", () => {
+    const state = readReleaseState();
+    expect(state.schemaVersion).toBe(1);
+    expect(state.publishedStable).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(isPrereleaseVersion(state.publishedStable)).toBe(false);
+    expect(state.maintenanceSeries.length).toBeGreaterThan(0);
+    expect(readPublishedStable()).toBe(state.publishedStable);
+  });
+
+  it("source version is a (possibly prerelease) semver owned by package.json", () => {
     const pkg = JSON.parse(readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
-    expect(readCurrentVersion()).toBe(pkg.version);
+    expect(readSourceVersion()).toBe(pkg.version);
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+  });
+
+  it("rejects a prerelease publishedStable", () => {
+    const errors = validateReleaseState({
+      schemaVersion: 1,
+      publishedStable: "0.5.0-dev.0",
+      maintenanceSeries: ["0.4.x"],
+    });
+    expect(errors.join("; ")).toContain("publishedStable");
+  });
+
+  it("rejects malformed maintenance series, schema, and unknown fields", () => {
+    expect(
+      validateReleaseState({ schemaVersion: 1, publishedStable: "0.4.1", maintenanceSeries: [] }),
+    ).not.toEqual([]);
+    expect(
+      validateReleaseState({
+        schemaVersion: 1,
+        publishedStable: "0.4.1",
+        maintenanceSeries: ["soon"],
+      }),
+    ).not.toEqual([]);
+    expect(
+      validateReleaseState({
+        schemaVersion: 2,
+        publishedStable: "0.4.1",
+        maintenanceSeries: ["0.4.x"],
+      }),
+    ).not.toEqual([]);
+    expect(
+      validateReleaseState({
+        schemaVersion: 1,
+        publishedStable: "0.4.1",
+        maintenanceSeries: ["0.4.x"],
+        sourceVersion: "0.5.0-dev.0",
+      }),
+    ).not.toEqual([]);
+    expect(validateReleaseState(null)).not.toEqual([]);
+  });
+});
+
+describe("release safety (prerelease tags can never pass as stable)", () => {
+  it("accepts only exact vX.Y.Z stable tags", () => {
+    for (const tag of ["v0.4.1", "v0.5.0", "v1.0.0", "v12.34.56"]) {
+      expect(isStableReleaseTag(tag), `exact tag '${tag}' must pass`).toBe(true);
+    }
+  });
+
+  it("rejects prerelease-shaped and malformed tags", () => {
+    for (const tag of ["v0.5.0-dev.0", "v0.1.1-beta", "v0.5.0-rc.1", "0.4.1", "v0.4", "v1.2.3.4"]) {
+      expect(isStableReleaseTag(tag), `tag '${tag}' must fail`).toBe(false);
+    }
+  });
+
+  it("classifies development versions as prereleases", () => {
+    expect(isPrereleaseVersion("0.5.0-dev.0")).toBe(true);
+    expect(isPrereleaseVersion("0.4.1")).toBe(false);
+  });
+});
+
+describe("version-parity guard probes (TASK-0078 A-E)", () => {
+  it("probe A: stale stable docs FAIL (README pins 0.4.0 while stable is 0.4.1)", () => {
+    const files = readTree();
+    const stable = readPublishedStable();
+    const readme = files["README.md"] ?? "";
+    files["README.md"] = readme.split(stable).join("0.4.0");
+    const { failures } = checkParity({ files });
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures.some((failure) => failure.startsWith("README.md"))).toBe(true);
+  });
+
+  it("probe B: source coupling drift FAILS (extension != development version)", () => {
+    const files = readTree();
+    const manifest = JSON.parse(files["extensions/vscode/package.json"] ?? "{}");
+    manifest.version = "0.4.1";
+    files["extensions/vscode/package.json"] = JSON.stringify(manifest);
+    const { failures } = checkParity({ files });
+    expect(
+      failures.some((failure) => failure.includes("ADR-0023 coupling")),
+      `expected a coupling failure, got: ${failures.join("; ")}`,
+    ).toBe(true);
+  });
+
+  it("probe C: stable docs may name stable WITHOUT naming the dev version (PASS)", () => {
+    const source = readSourceVersion();
+    const stable = readPublishedStable();
+    const extensionManifest = JSON.stringify({ version: source });
+    const ci = `contract '${source}' and ackit-vscode-${source}.vsix`;
+    const files: Record<string, string> = {};
+    for (const file of CURRENT_FILES) {
+      if (MUST_SHOW_STABLE.includes(file)) {
+        files[file] = `stable install @cynrath/agent-context-kit@${stable}`;
+      } else if (file === "extensions/vscode/package.json") {
+        files[file] = extensionManifest;
+      } else if (file === "package.json") {
+        files[file] = JSON.stringify({ version: source });
+      } else if (file === ".github/workflows/ci.yml") {
+        files[file] = ci;
+      } else {
+        files[file] = "no version claims here";
+      }
+    }
+    const { failures } = checkParity({ files });
+    expect(failures).toEqual([]);
+  });
+
+  it("probe D: historical references PASS on the live tree", () => {
+    const { failures } = checkParity();
+    expect(failures).toEqual([]);
+  });
+
+  it("probe E: invalid stable pointer FAILS instead of silently passing", () => {
+    const files = readTree();
+    const { failures } = checkParity({
+      files,
+      releaseState: {
+        schemaVersion: 1,
+        publishedStable: "0.5.0-dev.0",
+        maintenanceSeries: ["0.4.x"],
+      },
+    });
+    expect(
+      failures.some((failure) => failure.includes("published-stable")),
+      `expected a stable-pointer failure, got: ${failures.join("; ")}`,
+    ).toBe(true);
   });
 });
 
@@ -78,11 +257,20 @@ describe("version-parity guard end-to-end", () => {
     });
   }, 30000);
 
-  it("extension version is coupled to the package version", () => {
+  it("extension version is coupled to the source version", () => {
     const root = JSON.parse(readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
     const extension = JSON.parse(
       readFileSync(path.join(process.cwd(), "extensions/vscode/package.json"), "utf8"),
     );
     expect(extension.version).toBe(root.version);
+    expect(extension.version).toBe(readSourceVersion());
+  });
+
+  it("stable docs name the published stable pointer", () => {
+    const stable = readPublishedStable();
+    for (const file of MUST_SHOW_STABLE) {
+      const content = readFileSync(path.join(process.cwd(), file), "utf8");
+      expect(content.includes(stable), `${file} must name published stable ${stable}`).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## TASK-0078: Maintenance-aware release-state model

Closes TASK-0078 (completed + archived through the real `ackit task` gate on this branch; no second bookkeeping PR).

### Problem

Default-branch truth was internally inconsistent: source manifests said `0.4.0`, public stable (npm / GitHub / Marketplace) was `0.4.1` from the `maintenance/v0.4.1` line, README badges/pins said `0.4.0` — and the parity guard PASSED because it assumed `package.json == public stable`.

### Decision (ADR-0029, amends ADR-0023)

Four concepts, distinct owners, offline/deterministic:

- source/development: `package.json` = `0.5.0-dev.0` (NOT a release), extension manifest coupled, `ci.yml` extension job tracks it
- published stable: `release-state.json` (`publishedStable: 0.4.1`, `maintenanceSeries: ["0.4.x"]`)
- maintenance: `0.4.x` line on `maintenance/v0.4.1` (untouched)
- historical: allowlisted (CHANGELOG, docs/v0.2.0, ADRs, tasks, since-notes, debut notes, SARIF)

README badges are now version-agnostic (dynamic npm badge, `/releases/latest`); install/Action/Marketplace pins track stable `0.4.1`. `release.yml` unchanged — its exact-tag validator already fails closed on prerelease tags (pinned by `ci-pinning` + new `isStableReleaseTag` tests).

### Plan corrections in this PR

- TASK-0083 dependencies: `[TASK-0078]` -> `[TASK-0078, TASK-0081]` (it audits the TASK-0081 status snapshot)
- TASK-0078 acceptance: source/dev prerelease transition allowed per ADR; public/stable publication prohibited (npm/tags/Releases/Marketplace stay 0.4.1)

### Validation (exact-head)

- `pnpm test`: 103 files / 612 tests green
- lint, format:check, typecheck, build, gen:schemas idempotent, smoke:cli green
- `smoke:package`: `cynrath-agent-context-kit-0.5.0-dev.0.tgz` OK (nothing published)
- `vsce package`: `ackit-vscode-0.5.0-dev.0.vsix`, 653263 bytes <2MB, file list clean
- `check-version-parity` PASS (source 0.5.0-dev.0, stable 0.4.1); probes A-E green; offline-egress PASS; text-hygiene clean; doctor / task doctor / skills validate / scan --ci (readiness 88) PASS; `git diff --check` clean

### No-publication proof

- `git tag --list v0.5*`: empty
- `npm view @cynrath/agent-context-kit version`: 0.4.1
- `gh release list` latest: v0.4.1

### Scope discipline

- No TASK-0079..0086 work; no `maintenance/v0.4.1` or Browser Companion changes; no tag/publish/Release/deployment.
- Squash merge only after exact-head CI green + fresh verifier; then delete this branch.
