### PR TITLE
Release v0.5.1 - recovery from failed v0.5.0 gate (TASK-0088)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           node -e "
           const pkg=require('./extensions/vscode/package.json');
-          if(pkg.version!=='0.5.0') throw new Error('extension version must be 0.5.0');
+          if(pkg.version!=='0.5.1') throw new Error('extension version must be 0.5.1');
           if(pkg.publisher!=='Cynrath') throw new Error('publisher must be Cynrath');
           if(pkg.displayName!=='ACKit Toolkit') throw new Error('displayName must be ACKit Toolkit');
           if(!pkg.contributes.views.ackit.find(v=>v.id==='ackit.readiness')) throw new Error('ackit.readiness view missing');
@@ -142,9 +142,9 @@ jobs:
       - name: vsce package --no-dependencies
         run: |
           cd extensions/vscode
-          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.5.0.vsix
-          test -f ackit-vscode-0.5.0.vsix
-          ls -lh ackit-vscode-0.5.0.vsix
+          npx --yes @vscode/vsce package --no-dependencies --no-yarn --out ackit-vscode-0.5.1.vsix
+          test -f ackit-vscode-0.5.1.vsix
+          ls -lh ackit-vscode-0.5.1.vsix
       - name: VSIX content audit
         run: |
           cd extensions/vscode
@@ -155,12 +155,12 @@ jobs:
           ls -lh images/icon.png
           file images/icon.png
           # check VSIX size <2MB
-          size=$(stat -c%s ackit-vscode-0.5.0.vsix 2>/dev/null || stat -f%z ackit-vscode-0.5.0.vsix)
+          size=$(stat -c%s ackit-vscode-0.5.1.vsix 2>/dev/null || stat -f%z ackit-vscode-0.5.1.vsix)
           echo "VSIX size $size bytes"
           if [ "$size" -gt 2097152 ]; then echo "::error::VSIX >2MB"; exit 1; fi
           # check no secrets in VSIX
-          unzip -l ackit-vscode-0.5.0.vsix | head -20
-          if unzip -p ackit-vscode-0.5.0.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
+          unzip -l ackit-vscode-0.5.1.vsix | head -20
+          if unzip -p ackit-vscode-0.5.1.vsix extension/package.json | grep -q "AKIA"; then echo "::error::secret in VSIX"; exit 1; fi
       - name: Icon dimensions
         run: |
           cd extensions/vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to ACKit (`@cynrath/agent-context-kit`) are documented in th
 
 This project follows Semantic Versioning.
 
+## [0.5.1] - 2026-09-06
+
+Release recovery: v0.5.0 failed its tag-trigger release gate before any
+npm/GitHub Release publication (release workflow `34036439113` failed at
+`pnpm test` because `tests/e2e/chain-composition.test.ts` asserted the
+absence of `v0.5*` tags — impossible on the exact tagged checkout the
+workflow validates; npm v0.5.0 was never published and no GitHub Release
+`v0.5.0` was created). The immutable `v0.5.0` tag is preserved untouched
+as the failed-release marker. v0.5.1 contains the intended v0.5 feature
+set plus the release-context test correction.
+
+### Fixed
+
+- Chain-composition proof (`tests/e2e/chain-composition.test.ts`) no
+  longer asserts tag absence or hard-coded published-stable versions; it
+  proves status/projection parity (CLI ≡ SDK ≡ MCP ≡ Action),
+  verification-bound handoff round-trip, and completion — identically on
+  untagged and tagged checkouts. Release lifecycle assertions live in
+  the release/version contract tests.
+- New regression (`tests/contract/release-tag-context.test.ts`) proves
+  release/tagged-checkout execution cannot fail merely because the
+  triggering release tag exists (fixture repository carries a
+  release-shaped tag through status parity, handoff, and completion).
+
 ## [0.5.0] - 2026-09-05
 
 Provider-independent repository contract with evidence-backed completion:

--- a/docs/tasks/active/TASK-0087-v0-5-0-release-version-finalization-merge-tag-pu.md
+++ b/docs/tasks/active/TASK-0087-v0-5-0-release-version-finalization-merge-tag-pu.md
@@ -1,7 +1,7 @@
 ---
 id: "TASK-0087"
 title: "v0.5.0 release: version finalization, merge, tag, publish, and post-publish bookkeeping"
-status: active
+status: blocked
 schemaVersion: 2
 dependencies:
   - "TASK-0078"
@@ -87,12 +87,12 @@ TASK-0080..0086 are green (see goal execution record).
 
 ## Acceptance criteria
 
-- [ ] Source `0.5.0` + coupled VSIX version proven on the RC head; PR exact-head CI + verifier zero blockers before READY.
-- [ ] PR #20 squash-merged; post-merge master CI + Dogfood green before tag.
-- [ ] Immutable annotated `v0.5.0` on the validated master commit; OIDC publish + provenance; npm `latest` → `0.5.0`; npx + fresh-consumer smoke green; GitHub Release `v0.5.0` last.
-- [ ] Marketplace `Cynrath.ackit-vscode 0.5.0` published + verified.
-- [ ] Hosted docs updated via the protected flow with integrity green.
-- [ ] Post-publish pointer flipped (`0.5.0`) only after public verification; branches cleaned (`master` + Companion only); final public truth matches the goal record.
+- [!] Source `0.5.0` + coupled VSIX version proven on the RC head; PR exact-head CI + verifier zero blockers before READY. (BLOCKED: met pre-merge; release gate failed post-tag — see Completion notes.)
+- [!] PR #20 squash-merged; post-merge master CI + Dogfood green before tag. (BLOCKED: merged and tagged, but tag-trigger release workflow failed — see Completion notes.)
+- [!] Immutable annotated `v0.5.0` on the validated master commit; OIDC publish + provenance; npm `latest` → `0.5.0`; npx + fresh-consumer smoke green; GitHub Release `v0.5.0` last. (BLOCKED: never published — release workflow 34036439113 failed at `pnpm test` before npm/GitHub publication.)
+- [!] Marketplace `Cynrath.ackit-vscode 0.5.0` published + verified. (BLOCKED: never attempted — gated behind the failed release workflow.)
+- [!] Hosted docs updated via the protected flow with integrity green. (BLOCKED: never attempted for v0.5.0.)
+- [!] Post-publish pointer flipped (`0.5.0`) only after public verification; branches cleaned (`master` + Companion only); final public truth matches the goal record. (BLOCKED: `publishedStable` correctly remains `0.4.1`; superseded by TASK-0088 v0.5.1 recovery.)
 
 ## Test steps
 
@@ -121,4 +121,23 @@ TASK-0080..0086 are green (see goal execution record).
 
 ## Completion notes
 
-(placeholder — filled with per-surface evidence at gate time)
+BLOCKED / SUPERSEDED — v0.5.0 failed its release gate before any public
+publication; preserved as historical failed-release attempt. NOT completed.
+
+- Pre-merge lane completed: PR #20 squash-merged to `master` as
+  `aee1ddc8229b6878b281d8b60a49b2112bd5eee7`; post-merge master CI +
+  Dogfood green; immutable annotated `v0.5.0` created on that commit
+  (tag object `361a92e`, commit `aee1ddc`; never moved/deleted).
+- Tag-trigger release workflow `34036439113` (tag `v0.5.0`) FAILED at
+  `pnpm test`: `tests/e2e/chain-composition.test.ts:311` —
+  `AssertionError: expected 'v0.5.0' to be ''`. Root cause: the test
+  asserted `git tag --list v0.5*` is empty, which cannot hold on the
+  exact tagged checkout the release workflow validates. No npm publish,
+  no GitHub Release, no Marketplace publish occurred for v0.5.0
+  (verified: npm `0.5.0` 404, `latest` = `0.4.1`; `gh release view
+  v0.5.0` = not found; `release-state.json.publishedStable` = `0.4.1`).
+- Immutable `v0.5.0` tag left untouched per recovery rule (failed-release
+  marker, not a public release).
+- Superseded by TASK-0088 (v0.5.1 recovery: release-context test
+  correction + `0.5.0` → `0.5.1` bump + publication). This task is never
+  to be marked completed.

--- a/docs/tasks/active/TASK-0088-v0-5-1-release-recovery-release-context-test-cor.md
+++ b/docs/tasks/active/TASK-0088-v0-5-1-release-recovery-release-context-test-cor.md
@@ -1,0 +1,166 @@
+---
+id: "TASK-0088"
+title: "v0.5.1 release recovery: release-context test correction, version bump, and publication"
+status: active
+schemaVersion: 2
+dependencies:
+  - "TASK-0087"
+createdAt: "2026-09-06"
+completedAt: null
+---
+
+## Purpose
+
+Recover the failed v0.5.0 publication as v0.5.1 on the single temporary
+branch `release/v0.5.1`: correct the release-context test defect that
+failed workflow `34036439113`, bump coupled source versions
+`0.5.0` → `0.5.1`, ship the intended v0.5 feature set plus the test
+correction with truthful release notes (v0.5.0 never published), and
+publish v0.5.1 (npm + GitHub Release + Marketplace + hosted docs), then
+flip `publishedStable` to `0.5.1` and clean branches to
+`master` + `feat/browser-companion-v0.3` only. Immutable `v0.5.0` tag is
+never touched. TASK-0087 stays blocked/superseded history.
+
+Explicit user authorization (this task only): open the ONE recovery PR
+`release/v0.5.1` → `master`, squash-merge it when exact-head CI green,
+push the immutable annotated `v0.5.1` tag, let the existing
+tag-trigger OIDC/provenance release workflow publish npm + GitHub
+Release, publish `Cynrath.ackit-vscode 0.5.1` to the VS Code
+Marketplace, update hosted docs through the protected site PR flow, flip
+`release-state.json.publishedStable` to `0.5.1` after public
+verification (via the one minimal bookkeeping PR only if
+protected-master mechanics require it), and delete `release/v0.5.1`,
+`release/v0.5.0`, `maintenance/v0.4.1` after success (with the one
+non-`v*.*.*` archival tag only if the maintenance head holds unique
+bookkeeping). No force-push, no rebase, no history rewrite, no tag
+move/delete, no workflow dispatch.
+
+## Scope
+
+- `release/v0.5.1` from current `master` (`aee1ddc`); the ONLY
+  implementation branch. No other branches/PRs except the one recovery
+  PR plus at most one bookkeeping-only pointer PR if ADR-0029 mechanics
+  require it.
+- Fix `tests/e2e/chain-composition.test.ts`: remove tag-absence
+  assertions; remove hard-coded current published-stable assertions;
+  keep status/projection parity, verification, handoff, completion
+  focus; release lifecycle assertions belong in release/version contract
+  tests.
+- Add a regression proving release/tagged-checkout execution cannot fail
+  merely because the triggering release tag exists.
+- Bump coupled source versions `0.5.0` → `0.5.1` (`package.json`,
+  `extensions/vscode/package.json`, `.github/workflows/ci.yml` manifest
+  contract + VSIX filename).
+- Keep `release-state.json.publishedStable = 0.4.1` until v0.5.1 is
+  publicly verified on every surface.
+- CHANGELOG `0.5.1` entry + release notes stating: v0.5.0 failed its
+  release gate before npm/GitHub publication; v0.5.1 carries the
+  intended v0.5 feature set plus the release-context test correction;
+  never claim npm v0.5.0 was published.
+- Full gates, real tarball, VSIX, fresh verifier on the recovery head.
+- ONE recovery PR → exact-head CI green → merge → post-merge master
+  CI/Dogfood green → immutable annotated `v0.5.1` tag → OIDC workflow.
+- Verify npm `0.5.1` + `latest`, fresh install/npx, GitHub Release,
+  Marketplace, hosted docs; then pointer flip; then branch cleanup to
+  `master` + Companion only (both local and remote listings verified).
+
+## Out of scope
+
+- Any feature/fix beyond the test correction + version bump + release
+  mechanics above (lane is frozen).
+- Browser Companion (`feat/browser-companion-v0.3` stays paused/untouched).
+- Moving/deleting immutable tags `v0.4.1`, `v0.5.0`; force-push/history
+  rewrite; workflow dispatch; deployments.
+- Hosted-docs redesign; marketing beyond the correction note.
+
+## Dependencies
+
+- TASK-0087 (blocked/superseded failed v0.5.0 attempt — historical input only).
+
+## Affected files / expected areas
+
+- `tests/e2e/chain-composition.test.ts` (release-context correction)
+- New regression test for tagged-checkout release contexts
+  (e.g. `tests/contract/release-tag-context.test.ts` or adjacent contract location)
+- `package.json`, `extensions/vscode/package.json`
+  (ADR-0023 coupling `0.5.0` → `0.5.1`)
+- `.github/workflows/ci.yml` (manifest contract + VSIX filename tracking `0.5.1`)
+- `CHANGELOG.md` (`0.5.1` entry with failed-`v0.5.0`-gate truth)
+- `docs/tasks/active/TASK-0087-*` (blocked/superseded record)
+- `docs/tasks/active/TASK-0088-*` (this task)
+- `release-state.json` (pointer flip `0.4.1` → `0.5.1` ONLY after public verification)
+- Stable-claim surfaces on pointer flip (README, getting-started, VS Code README per ADR-0029)
+- Tag `v0.5.1`; recovery PR lifecycle; remote branch deletions post-success
+
+## Acceptance criteria
+
+- [ ] Chain-composition test asserts status/projection parity, verification, handoff, completion only; no tag-absence or hard-coded stable assertions; release lifecycle covered by contract tests.
+- [ ] Regression proves tagged-checkout execution passes with the triggering release tag present.
+- [ ] Source `0.5.1` + coupled VSIX version proven on the recovery head; PR exact-head CI + fresh verifier zero blockers before merge.
+- [ ] PR `release/v0.5.1` → `master` squash-merged; post-merge master CI + Dogfood green before tag.
+- [ ] Immutable annotated `v0.5.1` on the validated master commit; OIDC publish + provenance; npm `latest` → `0.5.1`; npx + fresh-consumer smoke green; GitHub Release `v0.5.1` last.
+- [ ] Marketplace `Cynrath.ackit-vscode 0.5.1` published + verified.
+- [ ] Hosted docs updated via the protected flow with integrity green.
+- [ ] Post-publish pointer flipped (`0.5.1`) only after public verification; branches cleaned (`master` + Companion only, both listings verified); final public truth matches the recovery record.
+
+## Test steps
+
+1. Recovery-head gates (install/lint/format/typecheck/build/test/gen:schemas idempotent/smokes/version-parity/offline/hygiene/config/doctor/task-doctor/skills/scan/diff-check).
+2. Targeted: chain-composition + new tagged-checkout regression green locally and in CI.
+3. Real package + VSIX proof with recorded versions/hashes/sizes (no node_modules, size limits, no secrets, no Companion).
+4. Fresh-verifier zero blockers on the recovery head.
+5. PR exact-head CI green → merge → post-merge CI/Dogfood evidence.
+6. Tag → workflow → registry/Marketplace/Release verification outputs (npm view, fresh install, npx smoke, `gh release view v0.5.1`).
+7. Hosted-docs PR + integrity evidence; pointer PR if required.
+8. Branch topology (local + remote listings) + final truth table in completion notes.
+
+## Security considerations
+
+- Offline-first invariant holds: no network calls, telemetry, or uploads in product code (REQ-GOV-001/002).
+- No secret values or absolute local paths in artifacts or task evidence (REQ-GOV-004/005).
+- Tag trigger stays exact `vX.Y.Z` fail-closed; archival tag (if any) verified non-triggering before branch deletion.
+- Package/VSIX audited for secrets and path leaks before publication.
+
+## Risks
+
+- Partial publication (npm done, Marketplace failed) → ordered per-surface checklist; no pointer flip until ALL surfaces verify.
+- Tag-trigger workflow drift → release.yml re-read before tagging; npm absence check first.
+- Protected-master mechanics forcing extra PRs → at most ONE minimal pointer PR; everything else rides the recovery PR pre-merge.
+- Stale-branch confusion → hard rule: only `release/v0.5.1` exists during recovery; cleanup verified on both listings.
+
+## Rollback plan
+
+- Pre-merge: focused revert on `release/v0.5.1`; PR stays draft.
+- Post-merge pre-tag: forward fix on master via PR (no history rewrite).
+- Post-publish: no rollback of immutable artifacts; forward patch release if a defect escapes.
+- Recovery failure: leave `v0.5.0` tag untouched; record blocker truthfully; report NO-GO.
+
+## Completion notes
+
+### Gate evidence — recovery head (pre-PR, branch `release/v0.5.1`)
+
+- `pnpm lint`: PASS (biome, 327 files; 1 format fix applied to the new regression file, re-verified clean).
+- `pnpm format:check`: PASS (309 files).
+- `pnpm typecheck` (`tsc --noEmit`): PASS.
+- `pnpm build` (`tsc -p tsconfig.build.json`): PASS.
+- `pnpm test` full suite: 704 passed / 3 skipped, 1 load-timeout
+  (`tests/unit/checkpoint/handoff.test.ts` single case, 60s timeout
+  while smoke ran concurrently — unrelated to this change); isolated
+  rerun: 10/10 PASS (36.95s). Focused: new regression 2/2 PASS;
+  fixed chain-composition 1/1 PASS **with immutable `v0.5.0` tag
+  present** (the exact failing condition of workflow 34036439113).
+- `node scripts/check-version-parity.mjs`: PASS (source 0.5.1, stable 0.4.1).
+- `node dist/cli/index.js config check`: OK.
+- `node dist/cli/index.js doctor`: all checks passed.
+- `node dist/cli/index.js task doctor`: integrity OK.
+- `node dist/cli/index.js scan --ci`: exit 0, readiness 88/100 (threshold 80 — pass).
+- `pnpm smoke:cli`: PASS.
+- `pnpm run smoke:package`: PASS (`cynrath-agent-context-kit-0.5.1.tgz`, v0.5.1).
+- Real VSIX: `ackit-vscode-0.5.1.vsix`, 12 files, 826,937 bytes (<2MB),
+  `vsce ls` shows no `node_modules`; manifest coupled at 0.5.1
+  (artifact removed after proof, never committed).
+- `git diff --check`: clean.
+- `v0.5.0` tag untouched (verified, still points at `aee1ddc`);
+  `release-state.json.publishedStable` stays `0.4.1`.
+
+(placeholder — publication + post-publish evidence appended at gate time)

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ackit-vscode",
   "displayName": "ACKit Toolkit",
   "description": "Offline-first agent readiness toolkit for VS Code",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "Cynrath",
   "engines": {
     "vscode": "^1.90.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cynrath/agent-context-kit",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "ACKit turns any repository into an agent-ready repository: instruction graph, agent skills, security scanning, context budgeting, task-first workflow, policy-as-code, and MCP integration. Offline-first and deterministic.",
   "keywords": [
     "ackit",

--- a/tests/contract/release-tag-context.test.ts
+++ b/tests/contract/release-tag-context.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Release/tagged-checkout execution regression (TASK-0088).
+ *
+ * The v0.5.0 tag-trigger release workflow (run 34036439113) failed at
+ * `pnpm test` with:
+ *
+ *   AssertionError: expected 'v0.5.0' to be '' // Object.is equality
+ *   ❯ tests/e2e/chain-composition.test.ts:311
+ *
+ * Root cause: the chain-composition proof asserted
+ * `git tag --list v0.5*` is empty — impossible on the exact tagged
+ * checkout the release workflow validates (the triggering tag exists by
+ * construction). No npm publish, GitHub Release, or Marketplace publish
+ * occurred; the tag was left as an immutable failed-release marker.
+ *
+ * Invariant: release/tagged-checkout execution must never fail merely
+ * because the triggering release tag exists. This file proves it two
+ * ways:
+ *
+ * 1. Static guard: the composition proof asserts nothing about
+ *    repository tags (a reintroduced tag-absence assertion fails here
+ *    first, with a pointer to this note).
+ * 2. Functional proof: a fixture repository carrying a release-shaped
+ *    tag (`v9.9.9`, stable-shaped like a triggering tag) still runs the
+ *    composed core — status projection parity (CLI ≡ SDK), handoff
+ *    export/import round-trip, and task completion — green.
+ *
+ * Release lifecycle assertions (source version, stable pointer, tag
+ * shape) belong in the version contract tests
+ * (`version-parity.test.ts`, `version-single-source.test.ts`,
+ * `release-notes.test.ts`, `ci-pinning.test.ts`) — never in composition
+ * proofs. No tag/publish/release side effects: the `v9.9.9` tag lives
+ * only inside the temp fixture repository, never in this checkout.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runCli } from "../../src/cli/index.js";
+import { buildStatusReport } from "../../src/index.js";
+import { EXIT_CODES } from "../../src/shared/exit-codes.js";
+
+/** Release-shaped tag carried by the fixture (stable `vX.Y.Z` shape). */
+const FIXTURE_TAG = "v9.9.9";
+
+let rootPath = "";
+let repoRoot = "";
+
+beforeAll(async () => {
+  rootPath = await mkdtemp(path.join(tmpdir(), "ackit-release-tag-"));
+  repoRoot = path.resolve(import.meta.dirname, "..", "..");
+  execFileSync("git", ["-C", rootPath, "init", "-q"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootPath, "config", "user.email", "t@example.com"], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", rootPath, "config", "user.name", "t"], { stdio: "ignore" });
+  await writeFile(path.join(rootPath, "README.md"), "# release-tag fixture\n", "utf8");
+  execFileSync("git", ["-C", rootPath, "add", "."], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootPath, "commit", "-q", "-m", "init"], { stdio: "ignore" });
+  // Mimic the release workflow's tagged checkout: the triggering release
+  // tag exists on the checkout under execution.
+  execFileSync("git", ["-C", rootPath, "tag", "-a", FIXTURE_TAG, "-m", "fixture release tag"], {
+    stdio: "ignore",
+  });
+});
+
+afterAll(async () => {
+  await rm(rootPath, { recursive: true, force: true });
+});
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function cli(args: string[]): Promise<CliResult> {
+  const chunks: string[] = [];
+  const errChunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  const originalErr = process.stderr.write;
+  process.stdout.write = ((chunk: string) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    errChunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const code = await runCli(["node", "ackit", "--root", rootPath, ...args]);
+    return { code, stdout: chunks.join(""), stderr: errChunks.join("") };
+  } finally {
+    process.stdout.write = originalWrite;
+    process.stderr.write = originalErr;
+  }
+}
+
+function fixtureTags(): string {
+  return execFileSync("git", ["-C", rootPath, "tag", "--list", "v*"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+describe("release/tagged-checkout execution (TASK-0088)", () => {
+  it("composition proof asserts nothing about repository tags", async () => {
+    const source = await readFile(
+      path.join(repoRoot, "tests", "e2e", "chain-composition.test.ts"),
+      "utf8",
+    );
+    expect(
+      source.includes("tag --list"),
+      "chain-composition must not shell out to 'git tag --list' (TASK-0088: tagged checkouts carry the triggering tag)",
+    ).toBe(false);
+    expect(
+      /expect\(tags/.test(source),
+      "chain-composition must not assert on a 'tags' variable (TASK-0088)",
+    ).toBe(false);
+    expect(
+      source.includes("no v0.5"),
+      "chain-composition must not assert tag absence (TASK-0088)",
+    ).toBe(false);
+  });
+
+  it("composed execution passes with a release-shaped tag present", async () => {
+    // Precondition: the triggering-shaped tag really exists (else this
+    // test would prove nothing about tagged checkouts).
+    expect(
+      fixtureTags()
+        .split("\n")
+        .map((tag) => tag.trim()),
+    ).toContain(FIXTURE_TAG);
+
+    const { TaskStore, serialize } = await import("../../src/core/tasks/index.js");
+    const created = await cli(["task", "create", "Release-tag fixture"]);
+    expect(created.code).toBe(EXIT_CODES.ok);
+    const taskId = /TASK-\d{4}/.exec(created.stdout)?.[0] ?? "";
+    expect(taskId).not.toBe("");
+    const store = new TaskStore(rootPath);
+    const found = await store.find(taskId);
+    if (found === null) throw new Error("task missing");
+    await writeFile(
+      path.join(rootPath, ...found.doc.relativePath.split("/")),
+      serialize(
+        found.doc.meta,
+        [
+          "## Acceptance criteria",
+          "",
+          "- [x] Tagged-checkout thing done.",
+          "",
+          "## Completion notes",
+          "",
+          "Tagged-checkout thing implemented; evidence recorded below.",
+        ].join("\n"),
+      ),
+      "utf8",
+    );
+    expect((await cli(["workflow", "set", taskId, "--profile", "quick"])).code).toBe(EXIT_CODES.ok);
+    expect((await cli(["task", "start", taskId])).code).toBe(EXIT_CODES.ok);
+    expect((await cli(["workflow", "advance", taskId])).code).toBe(EXIT_CODES.ok);
+    expect((await cli(["workflow", "advance", taskId])).code).toBe(EXIT_CODES.ok);
+
+    // Status projection parity (CLI ≡ SDK) holds with the tag present.
+    const cliJson = (await cli(["--json", "status", taskId])).stdout;
+    const sdkJson = JSON.stringify(await buildStatusReport(rootPath, taskId));
+    expect(JSON.parse(cliJson)).toEqual(JSON.parse(sdkJson));
+
+    // Handoff export/import round-trips with the tag present.
+    expect(
+      (
+        await cli([
+          "checkpoint",
+          "create",
+          taskId,
+          "--next-objective",
+          "tagged-checkout handoff objective",
+          "--next-command",
+          `ackit task complete ${taskId}`,
+        ])
+      ).code,
+    ).toBe(EXIT_CODES.ok);
+    expect(
+      (
+        await cli([
+          "checkpoint",
+          "export",
+          taskId,
+          "--format",
+          "json",
+          "--out",
+          ".ackit/tagged/handoff.json",
+        ])
+      ).code,
+    ).toBe(EXIT_CODES.ok);
+    const imported = await cli(["checkpoint", "import", ".ackit/tagged/handoff.json"]);
+    expect(imported.code).toBe(EXIT_CODES.ok);
+
+    // Completion succeeds with the tag present — the exact step the
+    // v0.5.0 release gate never reached because the tag assertion fired.
+    const completed = await cli(["task", "complete", taskId]);
+    expect(completed.code).toBe(EXIT_CODES.ok);
+
+    // The tag is still there: execution passed *with* it, not by removing it.
+    expect(
+      fixtureTags()
+        .split("\n")
+        .map((tag) => tag.trim()),
+    ).toContain(FIXTURE_TAG);
+  }, 120_000);
+});

--- a/tests/e2e/chain-composition.test.ts
+++ b/tests/e2e/chain-composition.test.ts
@@ -1,12 +1,23 @@
 /**
- * v0.5 chain-composition proof (TASK-0086).
+ * v0.5 chain-composition proof (TASK-0086, corrected TASK-0088).
  *
  * One fixture, every surface, one canonical snapshot: status projection
  * over bound verification state (0079/0080/0081) agrees byte-for-byte
  * across CLI ≡ SDK ≡ MCP ≡ Action; the portable handoff (0082) carries
- * that same status contract and validates fresh; release truth (0078)
- * holds (dev version unfinalized, stable pointer untouched, no v0.5.0
- * tag). No tag/publish/release side effects anywhere in this flow.
+ * that same status contract and validates fresh; the chain ends with
+ * task completion on the composed state.
+ *
+ * Release lifecycle assertions (source version, stable pointer, tag
+ * shape) belong in the release/version contract tests
+ * (tests/contract/version-parity.test.ts,
+ * tests/contract/version-single-source.test.ts,
+ * tests/contract/release-notes.test.ts,
+ * tests/contract/ci-pinning.test.ts,
+ * tests/contract/release-tag-context.test.ts) — never here. This test
+ * MUST pass on ordinary checkouts and on exact tagged checkouts alike
+ * (the release workflow validates the tagged commit); it asserts nothing
+ * about repository tags. No tag/publish/release side effects anywhere in
+ * this flow.
  */
 import { execFile as execFileCallback, execFileSync } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -91,7 +102,7 @@ async function mcpStatus(taskId: string): Promise<unknown> {
 }
 
 describe("v0.5 chain composition (TASK-0086)", () => {
-  it("one snapshot on every surface, handoff carrying it, release truth holding", async () => {
+  it("one snapshot on every surface, handoff carrying it, completion on the composed state", async () => {
     const { TaskStore, serialize } = await import("../../src/core/tasks/index.js");
     const { mkdir: mk } = await import("node:fs/promises");
     await cli(["intent", "new", "Chain the v0.5 line"]);
@@ -291,23 +302,12 @@ describe("v0.5 chain composition (TASK-0086)", () => {
     expect(imported.stdout).toContain("fresh");
 
     // ---- Chain end: completion succeeds on the composed state.
+    // NOTE (TASK-0088): release lifecycle assertions (source version,
+    // stable pointer, tag presence/absence) intentionally live in the
+    // release/version contract tests, not here — this composition proof
+    // must pass identically on untagged checkouts and on the exact
+    // tagged checkout the release workflow validates.
     const completed = await cli(["task", "complete", taskId]);
     expect(completed.code).toBe(EXIT_CODES.ok);
-
-    // ---- Release truth holds (0078 model): source finalized to the
-    // release line, stable pointer untouched pre-publish, no v0.5.0 tag.
-    const pkg = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8")) as {
-      version: string;
-    };
-    expect(pkg.version).toBe("0.5.0");
-    const releaseState = JSON.parse(
-      await readFile(path.join(repoRoot, "release-state.json"), "utf8"),
-    ) as { publishedStable: string };
-    expect(releaseState.publishedStable).toBe("0.4.1");
-    const tags = execFileSync("git", ["-C", repoRoot, "tag", "--list", "v0.5*"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    expect(tags.trim()).toBe("");
   }, 180_000);
 });


### PR DESCRIPTION
# Release v0.5.1 — recovery from failed v0.5.0 gate (TASK-0088)

## Truth first

- v0.5.0 **failed its tag-trigger release gate before any public
  publication**: release workflow `34036439113` failed at `pnpm test`
  (`tests/e2e/chain-composition.test.ts:311` —
  `expected 'v0.5.0' to be ''`). npm v0.5.0 was **never** published
  (`latest` is `0.4.1`); no GitHub Release `v0.5.0` exists.
- The immutable annotated `v0.5.0` tag is preserved untouched as the
  failed-release marker. TASK-0087 is recorded blocked/superseded
  (history, never to be completed).
- v0.5.1 contains the intended v0.5 feature set **plus** the
  release-context test correction. No other features/fixes (lane frozen).

## What changed

- `tests/e2e/chain-composition.test.ts`: removed tag-absence and
  hard-coded stable assertions; proves status/projection parity
  (CLI/SDK/MCP/Action), handoff round-trip, and completion — on untagged
  and tagged checkouts alike. Release lifecycle stays in contract tests.
- `tests/contract/release-tag-context.test.ts` (new): static guard plus
  functional proof that execution passes with a release-shaped tag
  present.
- Coupled source `0.5.0` → `0.5.1` (`package.json`,
  `extensions/vscode/package.json`, CI manifest contract + VSIX name).
- `CHANGELOG.md` `0.5.1` entry states the failed-gate truth.
- `release-state.json.publishedStable` stays `0.4.1` until v0.5.1 is
  publicly verified on every surface.

## Gates on this head (`8ed6ac6`)

- lint / format:check / typecheck / build: PASS
- Full `pnpm test`: 704 passed, 3 skipped; 1 load-timeout rerun green
  in isolation (10/10); focused regression 2/2 + chain 1/1 green with
  the `v0.5.0` tag present
- version-parity, config check, doctor, task doctor, `scan --ci`
  (readiness 88/100), `smoke:cli`, real-tarball `smoke:package`
  (`cynrath-agent-context-kit-0.5.1.tgz`), real VSIX
  (`ackit-vscode-0.5.1.vsix`, 807KB, <2MB, no node_modules)
- `git diff --check` clean; no artifacts committed

## Merge plan (single lane)

Require exact-head CI + Dogfood green, then squash-merge. Post-merge:
master CI/Dogfood green → immutable annotated `v0.5.1` tag → existing
OIDC release workflow → verify npm/Marketplace/Release/docs → pointer
flip → branch cleanup (`master` + Companion only).
