### PR TITLE
chore(release): flip publishedStable 0.5.1 -> 0.5.2 and close TASK-0089/TASK-0090

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ OpenCode, Copilot, Gemini, Cursor, Cline, any MCP-capable agent).
 ```bash
 # global (recommended)
 npm install --global @cynrath/agent-context-kit
-ackit --version  # 0.5.1
+ackit --version  # 0.5.2
 
 # one-shot, pinned
-npx --yes @cynrath/agent-context-kit@0.5.1 --version
-npx --yes @cynrath/agent-context-kit@0.5.1 --help
+npx --yes @cynrath/agent-context-kit@0.5.2 --version
+npx --yes @cynrath/agent-context-kit@0.5.2 --help
 
 # from source
 pnpm install --frozen-lockfile && pnpm build
@@ -306,7 +306,7 @@ More: [`docs/architecture/overview.md`](docs/architecture/overview.md)
 
 ### 🤖 GitHub Action
 
-Official `Cynrath/agent-context-kit@v0.5.1` (SHA-pinned for high-assurance):
+Official `Cynrath/agent-context-kit@v0.5.2` (SHA-pinned for high-assurance):
 
 ```yaml
 permissions:
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
-      - uses: Cynrath/agent-context-kit@v0.5.1
+      - uses: Cynrath/agent-context-kit@v0.5.2
         with:
           command: scan
           args: "--json"
@@ -365,7 +365,7 @@ ESM-only, `sideEffects:false`, `AbortSignal` cancellable, no `process.exit`. Ref
 
 ### 🧩 VS Code
 
-Extension is **published on the VS Code Marketplace** — [`Cynrath.ackit-vscode`](https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode) (`0.5.1`, `<2MB` VSIX, offline-first, no telemetry).
+Extension is **published on the VS Code Marketplace** — [`Cynrath.ackit-vscode`](https://marketplace.visualstudio.com/items?itemName=Cynrath.ackit-vscode) (`0.5.2`, `<2MB` VSIX, offline-first, no telemetry).
 
 From source:
 
@@ -422,7 +422,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the docs-first workflow.
 
 ### 🔖 Versioning
 
-Development: **`0.5.2`** on `master` · Latest stable: **`0.5.1`** · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases/latest) · `latest → 0.5.1` via OIDC Trusted Publishing with provenance. Stable pointer: [`release-state.json`](release-state.json). Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
+Development: **`0.5.2`** on `master` · Latest stable: **`0.5.2`** · [Changelog](CHANGELOG.md) · [Releases](https://github.com/Cynrath/agent-context-kit/releases/latest) · `latest → 0.5.2` via OIDC Trusted Publishing with provenance. Stable pointer: [`release-state.json`](release-state.json). Legacy `.NET/NuGet 1.0.0-rc.1` at `258918b` is frozen.
 
 ---
 

--- a/docs/guides/agent-integration.md
+++ b/docs/guides/agent-integration.md
@@ -19,7 +19,7 @@ duplicates.
 ## Managed-asset lifecycle (init → sync)
 
 > Availability: `ackit sync` is RELEASED in `0.4.0` and ships in published npm
-> `@cynrath/agent-context-kit@0.5.1`.
+> `@cynrath/agent-context-kit@0.5.2`.
 
 `ackit init` is the first-time onboarding; `ackit sync` is the later,
 version-aware reconciliation. Both run on the same ownership engine — the

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -14,17 +14,17 @@ npm install --global @cynrath/agent-context-kit
 ackit --version
 ```
 
-One-shot usage: `npx --yes @cynrath/agent-context-kit@0.5.1 --help` (pinned to stable `0.5.1`).
+One-shot usage: `npx --yes @cynrath/agent-context-kit@0.5.2 --help` (pinned to stable `0.5.2`).
 
 From a source checkout instead:
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
-node dist/cli/index.js --version  # 0.5.1
+node dist/cli/index.js --version  # 0.5.2
 ```
 
-## 30-second tour (verified commands — stable v0.5.1)
+## 30-second tour (verified commands — stable v0.5.2)
 
 ```bash
 ackit init --dry-run          # plan instruction shims + builtin skills

--- a/docs/tasks/archive/TASK-0089-v0-5-1-public-surface-parity-hosted-docs-and-vs-.md
+++ b/docs/tasks/archive/TASK-0089-v0-5-1-public-surface-parity-hosted-docs-and-vs-.md
@@ -1,11 +1,11 @@
 ---
 id: "TASK-0089"
 title: "v0.5.1 public surface parity, hosted docs and VS Code distribution audit"
-status: active
+status: completed
 schemaVersion: 2
 dependencies: []
 createdAt: "2026-09-06"
-completedAt: null
+completedAt: 2026-09-06
 ---
 
 ## Purpose
@@ -58,7 +58,7 @@ Explicit user authorization (this task only): open exactly ONE product PR `chore
 - [x] Root `index.html` has zero stale `0.4.1` in current surfaces (JSON-LD/hero/featured/install/docs), shows 0.5.1, and covers the v0.5 trust chain while keeping offline-first/deterministic/no-key/MCP-read-only visible; design preserved.
 - [x] `verify-site.mjs` asserts dynamic version parity + hosted v0.5 markers; `verify-site.mjs` green.
 - [x] Product validation (§21) fully green with no version bump (package 0.5.1, stable 0.5.1, npm latest 0.5.1); site validation (§24) green; rendered HTML inspected.
-- [ ] Exactly one product PR merged (exact-head CI/Dogfood green, squash) + one site PR merged (`docs-integrity` green); branches cleaned to `master` + `feat/browser-companion-v0.3` and `main`; live verification (§26) recorded.
+- [x] Exactly one product PR merged (exact-head CI/Dogfood green, squash) + one site PR merged (`docs-integrity` green); branches cleaned to `master` + `feat/browser-companion-v0.3` and `main`; live verification (§26) recorded.
 
 ## Test steps
 
@@ -120,3 +120,28 @@ INTERIM (10/11 criteria evidenced; PR merges + live verification pending):
   task-doctor/skills/scan(88/100)/diff-check green; no version bump.
 - Remaining: product PR → merge; site re-sync from merged master;
   site PR → merge; live verification (§26); branch cleanup (§27).
+
+## Final closure (v0.5.2 public verification, 2026-09-06/07)
+
+PR #23 corrected master docs, but the immutable v0.5.1 VSIX still
+carried the stale Marketplace README (`Version: 0.4.1` /
+`0.5.0-dev.0`) and CHANGELOG (top `0.4.0`, no `0.5.1`/`0.4.1`, `0.3.0`
+heading missing) — Marketplace Overview/Changelog drifted from version
+metadata. The v0.5.2 forward patch (TASK-0090, product PR #24) closed
+the final public-surface drift with zero v0.5.1 mutation. TASK-0089
+closes only now, after v0.5.2 public verification:
+
+- Product PR #24 squash-merged (`b0c9de1`, exact-head CI 12/12 +
+  Dogfood green); tag `v0.5.2` on the validated commit; release
+  workflow success (npm `@cynrath/agent-context-kit@0.5.2`, latest
+  `0.5.2` + provenance; GitHub Release `v0.5.2` Latest).
+- Marketplace `Cynrath.ackit-vscode 0.5.2` published once; live verified
+  separately: version metadata `0.5.2`, Overview `Version 0.5.2` with
+  canonical status wording (no `0.4.1`/`0.5.0-dev.0`), served VSIX
+  audited (manifest/README/CHANGELOG `0.5.2`, full repaired history,
+  SHA-256 `5475365A…E744`, identical to the GitHub Release asset).
+- GitHub Release `v0.5.2` carries `ackit-vscode-0.5.2.vsix`; the
+  historical `v0.5.1` asset is untouched.
+- Site PR #12 (Cynrath.github.io) merged (`45152e7`,
+  `docs-integrity` green): hosted docs + root UI `0.5.2`,
+  `verify-site.mjs` PASS; temp branches deleted both repos.

--- a/docs/tasks/archive/TASK-0090-v0-5-2-vs-code-marketplace-content-parity-patch-.md
+++ b/docs/tasks/archive/TASK-0090-v0-5-2-vs-code-marketplace-content-parity-patch-.md
@@ -1,12 +1,12 @@
 ---
 id: "TASK-0090"
 title: "v0.5.2 VS Code Marketplace content parity patch release"
-status: pending
+status: completed
 schemaVersion: 2
 dependencies:
   - TASK-0089
 createdAt: "2026-09-06"
-completedAt: null
+completedAt: 2026-09-06
 ---
 
 ## Purpose
@@ -103,31 +103,31 @@ force-push/rebase/history rewrite/workflow dispatch, extra branches.
 
 ## Acceptance criteria
 
-- [ ] Defect reproduced and recorded: Marketplace version metadata 0.5.1
+- [x] Defect reproduced and recorded: Marketplace version metadata 0.5.1
   CURRENT, Overview content STALE (0.4.1/0.5.0-dev.0); master README 0.5.1
   correct; v0.5.1 README/CHANGELOG stale as tagged.
-- [ ] Extension README header names 0.5.2 + all §5 UI/Tasks terms present,
+- [x] Extension README header names 0.5.2 + all §5 UI/Tasks terms present,
   zero false VS Code feature claims (fresh-verifier inspected).
-- [ ] Extension CHANGELOG has 0.5.2/0.5.1/0.4.1/0.4.0/0.3.0/0.2.2/0.2.1/
+- [x] Extension CHANGELOG has 0.5.2/0.5.1/0.4.1/0.4.0/0.3.0/0.2.2/0.2.1/
   0.2.0 sections with correct dates; 0.4.1 + 0.3.0 text verbatim from
   immutable tags; 0.5.1/0.5.2 entries factual.
-- [ ] `package.json` + `extensions/vscode/package.json` both 0.5.2;
+- [x] `package.json` + `extensions/vscode/package.json` both 0.5.2;
   description/keywords refreshed; `publishedStable` still 0.5.1 pre-publish.
-- [ ] New guards fail on the old defect shape (manifest 0.5.1 + README
+- [x] New guards fail on the old defect shape (manifest 0.5.1 + README
   0.4.1 + CHANGELOG 0.4.0) at source level AND packaged-VSIX level.
-- [ ] Full validation green (§11 incl. extension typecheck/build/test,
+- [x] Full validation green (§11 incl. extension typecheck/build/test,
   `vsce ls`, real 0.5.2 VSIX audited: manifest/README/CHANGELOG 0.5.2,
   publisher Cynrath, size < 2MB, SHA-256 recorded, no secrets).
-- [ ] ONE product PR merged (squash, exact-head CI/Dogfood green); post-merge
+- [x] ONE product PR merged (squash, exact-head CI/Dogfood green); post-merge
   RC rebuilt from master proves 7-way 0.5.2 parity.
-- [ ] npm `@cynrath/agent-context-kit@0.5.2` + latest 0.5.2; GitHub Release
+- [x] npm `@cynrath/agent-context-kit@0.5.2` + latest 0.5.2; GitHub Release
   v0.5.2 (+ VSIX asset, SHA-256); Marketplace `Cynrath.ackit-vscode` 0.5.2
   with current Overview/Changelog content verified live.
-- [ ] Site PR merged, `verify-site.mjs` green, hosted docs + root site 0.5.2.
-- [ ] `publishedStable` flipped to 0.5.2 only after all surfaces verified.
-- [ ] TASK-0090 completed (no force) + archived with evidence; `task doctor`
+- [x] Site PR merged, `verify-site.mjs` green, hosted docs + root site 0.5.2.
+- [x] `publishedStable` flipped to 0.5.2 only after all surfaces verified.
+- [x] TASK-0090 completed (no force) + archived with evidence; `task doctor`
   green; then TASK-0089 completed (no force) + archived with §20 notes.
-- [ ] Final branches: product `master` + `feat/browser-companion-v0.3`;
+- [x] Final branches: product `master` + `feat/browser-companion-v0.3`;
   site `main`. Final matrix + SUCCESS decision reported.
 
 ## Test steps
@@ -164,9 +164,45 @@ new patch release task with fresh user authorization.
 
 ## Completion notes
 
-(pending — filled with real evidence at closure: product PR + merge SHA,
-tag, release workflow run, npm/GitHub/Marketplace proofs, VSIX SHA-256,
-site PR + merge SHA, stable-pointer PR, task closures)
+v0.5.2 Marketplace content parity patch: SUCCESS. All acceptance
+criteria evidenced with real artifacts (no force at any gate):
+
+- Defect: Marketplace version metadata 0.5.1 CURRENT, Overview content
+  STALE (README `0.4.1`/`0.5.0-dev.0`, CHANGELOG top `0.4.0`, no
+  `0.5.1`/`0.4.1`, `0.3.0` heading missing) — recorded before any change.
+- Product PR #24 (`release/v0.5.2` → `master`), squash-merged `b0c9de1`
+  with exact-head CI 12/12 + Dogfood green. Commits: plan `210a061`,
+  extension fix `5a2d5d9`, guards/sync `2605158`, CI path fix `b822de3`
+  (vsce lowercases README/CHANGELOG in the VSIX — caught by CI, fixed,
+  re-verified).
+- Tag `v0.5.2` (annotated, on `b0c9de1`); release workflow `34064084820`
+  success: npm `@cynrath/agent-context-kit@0.5.2` + `latest 0.5.2` with
+  provenance, fresh consumer smoke (`0.5.2`), GitHub Release `v0.5.2`
+  (Latest). npx-on-Windows shim fails locally (environment), workflow
+  npx smoke green + fresh `npm install` consumer smoke `0.5.2`.
+- Marketplace `Cynrath.ackit-vscode 0.5.2` published once (user-executed
+  `vsce publish`, PAT never in repo/env); live verified separately:
+  version metadata `0.5.2`, Overview `Version 0.5.2` + canonical status
+  wording, no `0.4.1`/`0.5.0-dev.0`; Marketplace-served VSIX audited
+  (manifest/README/CHANGELOG `0.5.2`, full repaired history,
+  SHA-256 `5475365A0194DF3B1263DA1B48C148DB8A839D8A20E929174992843EB573E744`
+  identical to the GitHub Release asset `ackit-vscode-0.5.2.vsix`,
+  830356 bytes; `v0.5.1` asset untouched).
+- Site PR #12 merged (`45152e7`, `docs-integrity` green): 30 generated
+  pages + `llms` + sitemap re-synced (idempotent), root UI 6/6 surfaces
+  `0.5.2`, `verify-site.mjs` PASS; temp branches deleted both repos.
+- Stable pointer flipped `0.5.1 → 0.5.2` (+ stable-bound pins) in the
+  minimal bookkeeping flip PR only after every surface above verified.
+- Validation: lint/format/typecheck/build green; `pnpm test` green
+  (116 files, 715 passed — one clean run; earlier Windows runs showed
+  worker-contention timeouts in git-init hooks, every failed file
+  re-passed in isolation, pristine-master baseline green, CI ubuntu
+  green throughout); schemas idempotent; smokes green; parity/
+  offline/hygiene/config/doctor/task-doctor/skills/scan(88)/diff green;
+  extension typechecks + build + 16/16 Electron tests on VS Code
+  1.136.1; 7-way 0.5.2 parity proven on merged master.
+- No v0.5.1 mutation (tag/package/asset), no tag moves, no Browser
+  Companion changes, no force-push/rebase.
 
 ## Status note (single-active rule, recorded 2026-09-06)
 
@@ -186,3 +222,10 @@ implementation, and briefly `start`ed. It is held at `pending` (not
 - No gate is weakened: no test/typecheck/lint rule changed for this; the
   status value is truthful (planned, implementation in review, execution
   pending merge).
+
+Addendum (closure sequence, recorded on the flip branch): the freshly
+built CLI additionally refuses `task start` while another task is
+active (`TaskStore.start` single-active guard — the earlier successful
+start ran under a stale pre-session `dist/`). Closure therefore runs
+in CLI-legal order: complete TASK-0089 first (acceptance met), then
+start TASK-0090, complete it, archive both. No manual status edits.

--- a/release-state.json
+++ b/release-state.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "publishedStable": "0.5.1",
+  "publishedStable": "0.5.2",
   "maintenanceSeries": ["0.4.x"]
 }


### PR DESCRIPTION
Post-publication bookkeeping only (ADR-0029, precedent #22). Every public surface verified 0.5.2 before this pointer moves: npm latest, GitHub Release + VSIX asset, Marketplace version/Overview/Changelog (served-VSIX audit hash-identical to Release asset), hosted docs + root site (site PR #12 merged, verify-site green). Changes: release-state.json pointer, stable-bound doc pins, TASK-0089 + TASK-0090 completed without force and archived with evidence. task doctor green. No code, no manifest versions, no tags.